### PR TITLE
Implement `Result<T,E>` collection for non-empty iterator

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -670,7 +670,6 @@ impl<A, E, V> FromNonEmptyIterator<Result<A, E>> for Result<V, E>
 where
     V: FromNonEmptyIterator<A>,
 {
-    //fn from_nonempty_iter<I: IntoIterator<Item = std::result::Result<A, E>>>(iter: I) -> std::result::Result<V, E> {
     fn from_nonempty_iter<I>(iter: I) -> Result<V, E>
     where
         I: IntoNonEmptyIterator<Item = Result<A, E>>,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -6,6 +6,8 @@ use std::hash::Hash;
 use std::iter::{Product, Sum};
 use std::result::Result;
 
+use crate::NEVec;
+
 // Iterator structs which _always_ have something if the source iterator is non-empty:
 //
 // - [x] Chain (if one, the other, or both are nonempty)
@@ -674,8 +676,6 @@ where
     where
         I: IntoNonEmptyIterator<Item = Result<A, E>>,
     {
-        use crate::NEVec;
-
         let (head, rest) = iter.into_nonempty_iter().first();
         let head: A = head?;
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -836,4 +836,37 @@ mod tests {
             Ok(())
         }
     }
+
+    #[test]
+    fn test_result_collect() {
+        use crate::{IntoNonEmptyIterator, NonEmptyIterator};
+
+        let nonempty = nev![2, 4, 8];
+        let output = nonempty
+            .into_nonempty_iter()
+            .map(|n| {
+                if n % 2 == 0 {
+                    Ok(n)
+                } else {
+                    Err("odd number!")
+                }
+            })
+            .collect::<Result<NEVec<u32>, &'static str>>();
+
+        assert_eq!(output, Ok(nev![2, 4, 8]));
+
+        let nonempty = nev![2, 1, 8];
+        let output = nonempty
+            .into_nonempty_iter()
+            .map(|n| {
+                if n % 2 == 0 {
+                    Ok(n)
+                } else {
+                    Err("odd number!")
+                }
+            })
+            .collect::<Result<NEVec<u32>, &'static str>>();
+
+        assert_eq!(output, Err("odd number!"));
+    }
 }


### PR DESCRIPTION
This PR implements `FromNonEmptyIterator` for `Result<T,E>`, so that non-empty iterators of `Result` types can use the `.collect::<Result<NEVec<_>, Error>>()` idiom to create a single `Result` containing a nonempty collection in its `Ok` branch.