### PR TITLE
Nonempty slice type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@
 pub mod iter;
 pub mod map;
 pub mod set;
+pub mod slice;
 pub mod vector;
 
 pub use iter::FromNonEmptyIterator;
@@ -111,4 +112,5 @@ pub use iter::IntoNonEmptyIterator;
 pub use iter::NonEmptyIterator;
 pub use map::NEMap;
 pub use set::NESet;
+pub use slice::NESlice;
 pub use vector::NEVec;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -114,7 +114,6 @@ mod tests {
         use crate::{IntoNonEmptyIterator, NonEmptyIterator};
 
         let slice = [0, 1, 2, 3];
-        //let nonempty = NESlice::from_slice(&slice).unwrap();
         let nonempty = NESlice::new(&slice[0], &slice[1..]);
         for (i, n) in nonempty.into_nonempty_iter().enumerate() {
             assert_eq!(i as i32, *n);

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,0 +1,123 @@
+//! Non-empty Slices.
+use crate::iter::{IntoNonEmptyIterator, NonEmptyIterator};
+use std::iter::{Chain, Once, Skip};
+
+/// Non-empty slice
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NESlice<'a, T> {
+    /// The element of the non-empty Vector. Always exists.
+    pub head: &'a T,
+
+    /// The remaining elements of the non-empty Vector, perhaps empty.
+    pub tail: &'a [T],
+}
+
+impl<'a, T> NESlice<'a, T> {
+    /// Create a new non-empty list with an initial element.
+    pub fn new(head: &'a T, tail: &'a [T]) -> Self {
+        Self { head, tail }
+    }
+
+    /// Get the first element. Never fails.
+    pub const fn first(&self) -> &T {
+        &self.head
+    }
+
+    /// Using `from_slice` gives a proof that the input slice is non-empty in the Some
+    /// branch
+    pub fn from_slice(slice: &'a [T]) -> Option<Self> {
+        slice.split_first().map(|(head, tail)| Self { head, tail })
+    }
+
+    /// Get the length of the slice.
+    pub fn len(&self) -> usize {
+        self.tail.len() + 1
+    }
+
+    /// Generates a standard iterator
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter {
+            head: &self.head,
+            iter: std::iter::once(self.head).chain(self.tail.iter()),
+        }
+    }
+}
+
+impl<'a, T> IntoNonEmptyIterator for NESlice<'a, T> {
+    type Item = &'a T;
+
+    type IntoIter = Iter<'a, T>;
+
+    fn into_nonempty_iter(self) -> Self::IntoIter {
+        Iter {
+            head: &self.head,
+            iter: std::iter::once(self.head).chain(self.tail.iter()),
+        }
+    }
+}
+
+/// A non-empty iterator over the values of an [`NESlice`].
+#[derive(Debug)]
+pub struct Iter<'a, T: 'a> {
+    head: &'a T,
+    iter: Chain<Once<&'a T>, std::slice::Iter<'a, T>>,
+}
+
+impl<'a, T> NonEmptyIterator for Iter<'a, T> {
+    type Item = &'a T;
+    type IntoIter = Skip<Chain<Once<&'a T>, std::slice::Iter<'a, T>>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn first(self) -> (Self::Item, Self::IntoIter) {
+        (self.head, self.iter.skip(1))
+    }
+}
+
+impl<'a, T> IntoIterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    type IntoIter = Chain<Once<&'a T>, std::slice::Iter<'a, T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::NESlice;
+
+    #[test]
+    fn test_from_conversion() {
+        let slice = [1, 2, 3, 4, 5];
+
+        let nonempty_slice = NESlice::from_slice(&slice);
+
+        let nonempty_slice = nonempty_slice.unwrap();
+        assert_eq!(nonempty_slice.head, &1);
+        assert_eq!(nonempty_slice.tail, &[2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_iter_syntax() {
+        let slice = [0, 1, 2, 3];
+        let nonempty = NESlice::from_slice(&slice);
+        for n in &nonempty {
+            assert_eq!(*n, *n); // Prove that we're dealing with references.
+        }
+    }
+    #[test]
+    fn test_into_nonempty_iter() {
+        use crate::{IntoNonEmptyIterator, NonEmptyIterator};
+
+        let slice = [0, 1, 2, 3];
+        //let nonempty = NESlice::from_slice(&slice).unwrap();
+        let nonempty = NESlice::new(&slice[0], &slice[1..]);
+        for (i, n) in nonempty.into_nonempty_iter().enumerate() {
+            assert_eq!(i as i32, *n);
+        }
+    }
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -567,6 +567,11 @@ impl<T> NEVec<T> {
             }
         }
     }
+
+    /// Yields a `NESlice`
+    pub fn as_nonempty_slice(&self) -> crate::NESlice<T> {
+        crate::NESlice::new(&self.head, &self.tail)
+    }
 }
 
 impl<T> From<NEVec<T>> for Vec<T> {
@@ -868,5 +873,14 @@ mod tests {
             .collect::<Result<NEVec<u32>, &'static str>>();
 
         assert_eq!(output, Err("odd number!"));
+    }
+
+    #[test]
+    fn test_as_slice() {
+        let nonempty = NEVec::from((0, vec![1, 2, 3]));
+        assert_eq!(
+            nonempty.as_nonempty_slice(),
+            crate::NESlice::new(&0, &[1, 2, 3])
+        );
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -569,7 +569,7 @@ impl<T> NEVec<T> {
     }
 
     /// Yields a `NESlice`
-    pub fn as_nonempty_slice(&self) -> crate::NESlice<T> {
+    pub fn as_nonempty_slice<'b>(&'b self) -> crate::NESlice<'b, T> {
         crate::NESlice::new(&self.head, &self.tail)
     }
 }


### PR DESCRIPTION
This PR adds a new type `NESlice`, for representing non-empty slices in an analogous way to `NEVec`.