### PR TITLE
Implement FromNonEmptyIterator for NEMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `nonempty-collections`
 
+## Unreleased
+
+#### Added
+
+- `FromNonEmptyIterator` impls for `NEMap` and `NESet`.
+- `Debug`, `Clone`, `PartialEq`, and `Eq` for `NEMap`.
+
 ## 0.1.3 (2023-09-15)
 
 #### Added

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,6 +1,6 @@
 //! Non-empty [`HashMap`]s.
 
-use crate::{IntoNonEmptyIterator, NonEmptyIterator};
+use crate::{FromNonEmptyIterator, IntoNonEmptyIterator, NonEmptyIterator};
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
@@ -349,6 +349,25 @@ impl<K, V, S> IntoNonEmptyIterator for NEMap<K, V, S> {
 
     fn into_nonempty_iter(self) -> Self::IntoIter {
         crate::iter::once((self.head_key, self.head_val)).chain(self.tail)
+    }
+}
+
+impl<K, V, S> FromNonEmptyIterator<(K, V)> for NEMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    fn from_nonempty_iter<I>(iter: I) -> Self
+    where
+        I: IntoNonEmptyIterator<Item = (K, V)>,
+    {
+        let ((head_key, head_val), rest) = iter.into_nonempty_iter().first();
+
+        NEMap {
+            head_key,
+            head_val,
+            tail: rest.into_iter().collect(),
+        }
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,7 +1,7 @@
 //! Non-empty Sets.
 
 use crate::iter::NonEmptyIterator;
-use crate::IntoNonEmptyIterator;
+use crate::{FromNonEmptyIterator, IntoNonEmptyIterator};
 use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::hash::{BuildHasher, Hash};
@@ -449,6 +449,31 @@ impl<T, S> IntoNonEmptyIterator for NESet<T, S> {
 
     fn into_nonempty_iter(self) -> Self::IntoIter {
         crate::iter::once(self.head).chain(self.tail)
+    }
+}
+
+/// ```
+/// use nonempty_collections::*;
+///
+/// let s0 = nes![1, 2, 3];
+/// let s1: NESet<_> = s0.iter().cloned().collect();
+/// assert_eq!(s0, s1);
+/// ```
+impl<T, S> FromNonEmptyIterator<T> for NESet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    fn from_nonempty_iter<I>(iter: I) -> Self
+    where
+        I: IntoNonEmptyIterator<Item = T>,
+    {
+        let (head, rest) = iter.into_nonempty_iter().first();
+
+        NESet {
+            head,
+            tail: rest.into_iter().collect(),
+        }
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -599,9 +599,11 @@ impl<T> From<(T, Vec<T>)> for NEVec<T> {
 }
 
 /// ```
-/// use nonempty_collections::nev;
+/// use nonempty_collections::*;
 ///
-/// let v = nev![1, 2, 3];
+/// let v0 = nev![1, 2, 3];
+/// let v1: NEVec<_> = v0.iter().cloned().collect();
+/// assert_eq!(v0, v1);
 /// ```
 impl<T> FromNonEmptyIterator<T> for NEVec<T> {
     fn from_nonempty_iter<I>(iter: I) -> Self


### PR DESCRIPTION
This adds the equivalent of the standard library's [`impl<K, V, S> FromIterator<(K, V)> for HashMap<K, V, S>`](https://doc.rust-lang.org/nightly/std/collections/hash_map/struct.HashMap.html#impl-FromIterator%3C(K,+V)%3E-for-HashMap%3CK,+V,+S%3E).