### PR TITLE
Nonzero

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let v: NEVec<u32> = nev![1, 2, 3];
 let s: NESet<u32> = nes![1, 2, 2, 3]; // 1 2 3
 let m: NEMap<&str, bool> = nem!["a" => true, "b" => false];
 assert_eq!(1, v.head);
-assert_eq!(3, s.len());
+assert_eq!(3, s.len().get());
 assert!(m.get("a").unwrap());
 ```
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,7 +1,10 @@
 //! Non-empty Slices.
 
 use crate::iter::{IntoNonEmptyIterator, NonEmptyIterator};
-use std::iter::{Chain, Once, Skip};
+use std::{
+    iter::{Chain, Once, Skip},
+    num::NonZeroUsize,
+};
 
 /// A non-empty slice. Like [`crate::NEVec`], but guaranteed to have borrowed
 /// contents.
@@ -38,8 +41,9 @@ impl<'a, T> NESlice<'a, T> {
     }
 
     /// Get the length of the slice.
-    pub fn len(&self) -> usize {
-        self.tail.len() + 1
+    pub fn len(&self) -> NonZeroUsize {
+        let len = self.tail.len();
+        unsafe { NonZeroUsize::new_unchecked(len + 1) }
     }
 
     /// Generates a standard iterator.


### PR DESCRIPTION
Replaced `usize` with `NonZeroUsize` wherever it would make sense to better reflect invariants. Also fixed the fact that `assert_eq!(NESet::with_capacity(0, _).capacity(), 1)`, this is no longer the case, same for `NEMap`.

There is still an issue like, what should happen when `tail` of collections has `usize::MAX` elements (which can happen currently) and we call `len()` on the NECollection, currently it'll overflow but I'm not sure whether checking if we're at `usize::MAX - 1` on every insert to account for this case is a good idea.

Also, this crate is great, really useful, thanks for it:)