### PR TITLE
add IntoIteratorExt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ pub mod vector;
 #[cfg(feature = "indexmap")]
 pub use index_map::NEIndexMap;
 pub use iter::FromNonEmptyIterator;
+pub use iter::IntoIteratorExt;
 pub use iter::IntoNonEmptyIterator;
 pub use iter::IteratorExt;
 pub use iter::NonEmptyIterator;


### PR DESCRIPTION
Adds `IntoIteratorExt` such that
```rust
vec![0].into_iter().to_nonempty_iter();
```
becomes
```rust
vec![0].try_into_nonempty_iter();
```
The reason for using 'into' is to follow [Rust's naming conventions](https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv) as calling this method consumes `self`.

I also use 'try' because that seems to be the convention for fallible conversions (e.g. `TryFrom`), however, `TryFrom` returns a `Result` while this returns an `Option`. An option seems simpler to me but I'm happy to discuss alternatives.