### PR TITLE
Fix iter bug

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -263,6 +263,7 @@ impl<T> NEVec<T> {
         Iter {
             head: &self.head,
             iter: std::iter::once(&self.head).chain(self.tail.iter()),
+            at_start: true,
         }
     }
 
@@ -737,6 +738,7 @@ impl<T> FromNonEmptyIterator<T> for NEVec<T> {
 pub struct Iter<'a, T: 'a> {
     head: &'a T,
     iter: Chain<Once<&'a T>, std::slice::Iter<'a, T>>,
+    at_start: bool,
 }
 
 impl<'a, T> NonEmptyIterator for Iter<'a, T> {
@@ -744,11 +746,12 @@ impl<'a, T> NonEmptyIterator for Iter<'a, T> {
     type IntoIter = Skip<Chain<Once<&'a T>, std::slice::Iter<'a, T>>>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        self.at_start = false;
         self.iter.next()
     }
 
     fn first(self) -> (Self::Item, Self::IntoIter) {
-        (self.head, self.iter.skip(1))
+        (self.head, self.iter.skip(usize::from(self.at_start)))
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -999,3 +999,41 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::nev;
+    use crate::NonEmptyIterator;
+
+    #[test]
+    fn test() {
+        let v = nev![0, 1, 2];
+
+        // first call first()
+        let iter = v.iter().copied();
+        let (first, mut rest) = iter.first();
+        assert_eq!(0, first);
+        assert_eq!(Some(1), rest.next());
+        assert_eq!(Some(2), rest.next());
+        assert_eq!(None, rest.next());
+
+        // call first() after next()
+        let mut iter = v.iter().copied();
+        assert_eq!(Some(0), iter.next());
+        let (first, mut rest) = iter.first();
+        assert_eq!(0, first);
+        assert_eq!(Some(1), rest.next());
+        assert_eq!(Some(2), rest.next());
+        assert_eq!(None, rest.next());
+
+        // call first() after iterating over the entire iterator
+        let mut iter = v.iter().copied();
+        assert_eq!(Some(0), iter.next());
+        assert_eq!(Some(1), iter.next());
+        assert_eq!(Some(2), iter.next());
+        assert_eq!(None, iter.next());
+        let (first, mut rest) = iter.first();
+        assert_eq!(0, first);
+        assert_eq!(None, rest.next());
+    }
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1039,4 +1039,12 @@ mod test {
         assert_eq!(0, first);
         assert_eq!(None, rest.next());
     }
+
+    #[test]
+    fn test2() {
+        let v = nev![8, 0];
+        let mut iter = v.iter().copied();
+        iter.next();
+        assert_eq!(vec![1], iter.map(|x| x + 1).collect::<Vec<_>>());
+    }
 }


### PR DESCRIPTION
All non-empty iterators seem to implicitly assume that `first()` should be called before any call to `next()`. If this assumption is violated this could result in skipping a value which could lead to data loss. I added a test case that failed without the fix.

Note that I only added the test and fix for `NEVec`. I didn't fix it for all implementations yet because I'm wondering if instead of this fix there is a better API out there that would enforce correctness. An alternative API could for example be to remove `next()` and rename `first()` to `next()`:
```rust
fn next(self) -> (Self::Item, Self::IntoIter);
```
This would guarantee correct behavior but it would be a breaking change and I'm not sure if this is more ergonomic than the current API. Anyway, looking forward to hear your perspective on this.