### PR TITLE
fix: index out of bound when chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `nonempty-collections`
 
+## Unreleased
+
+#### Fixed
+
+- More edge cases involving `NEChunks`.
+
 ## 0.2.2 (2024-03-18)
 
 #### Fixed

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -157,7 +157,6 @@ impl<'a, T> NonEmptyIterator for NEChunks<'a, T> {
         } else if self.index >= self.tail.len() {
             None
         } else {
-            println!("index: {}, tail: {}", self.index, self.tail.len());
             let end = self.index + self.window.get();
             let slc: &'a [T] = &self.tail[self.index..end];
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -294,16 +294,16 @@ mod tests {
         }
     }
 
-    // A test to reproduce index our of range errors
+    // A test to reproduce index out of range errors
     // and ensure that the `NEChunks` iterator works
+    // as expected.
     #[test]
     fn chunks_into_iter_with_chunk_size_over_len() {
         let v = nev![1, 2, 3];
         let n = NonZeroUsize::new(4).unwrap();
         let c = v.nonempty_chunks(n);
 
-        // Just a demonstration that `NEChunks` can be used as-is with a `for`
-        // loop.
+        // Iterating over should not produce any errors.
         for slice in c {
             let _: NESlice<'_, i32> = slice;
         }


### PR DESCRIPTION
This PR fixes a certain number of issues when using the iterator from `NEChunks`.

I also added / enriched tests to ensure the missed edge cases are not going to blow up on next modification.