### PR TITLE
instruct docs.rs to use all-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ indexmap = { version = "2.2.5", optional = true }
 
 [dev-dependencies]
 serde_json = "1"
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
Currently, [the documentation on doc.rs](https://docs.rs/nonempty-collections/latest/nonempty_collections/) doesn't show the `NEIndexMap` because it doesn't generate the documentation for it. This PR fixes that.