### PR TITLE
Add impls for arrays

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -1,4 +1,19 @@
-//! Extends non-zero length arrays with conversion methods to non-empty collections.
+//! Extends non-zero length arrays with conversion methods to non-empty
+//! collections.
+//!
+//! Since fixed-size arrays are by definition already not empty, they aren't
+//! given a special wrapper type like [`crate::NEVec`]. Instead, we enable them
+//! to be easily iterated over in a compatible way:
+//!
+//! ```
+//! use nonempty_collections::*;
+//!
+//! let a: [u32; 4] = [1, 2, 3, 4];
+//! let v: NEVec<_> = a.into_nonempty_iter().map(|n| n + 1).collect();
+//! assert_eq!(nev![2, 3, 4, 5], v);
+//! ```
+//!
+//! See [`NonEmptyArrayExt`] for more conversions.
 
 use std::num::NonZeroUsize;
 
@@ -11,17 +26,22 @@ use crate::NonEmptyIterator;
 /// # Examples
 ///
 /// Create a non-empty slice of an array:
+///
 /// ```
 /// # use nonempty_collections::*;
 /// assert_eq!(NESlice::new(&1, &[2]), [1, 2].as_nonempty_slice());
 /// ```
+///
 /// Get the length of an array as a [`NonZeroUsize`]:
+///
 /// ```
 /// # use nonempty_collections::NonEmptyArrayExt;
 /// # use std::num::NonZeroUsize;
 /// assert_eq!(NonZeroUsize::MIN, [1].nonzero_len());
 /// ```
+///
 /// Copy into a non-empty vec:
+///
 /// ```
 /// # use nonempty_collections::*;
 /// assert_eq!(nev![4], [4].to_nonempty_vec());
@@ -33,7 +53,7 @@ pub trait NonEmptyArrayExt<T> {
     /// Returns the length of this array as a [`NonZeroUsize`].
     fn nonzero_len(&self) -> NonZeroUsize;
 
-    /// Copies `self` into a new [`NEVec`].
+    /// Copies `self` into a new [`crate::NEVec`].
     fn to_nonempty_vec(&self) -> crate::NEVec<T>
     where
         T: Clone;
@@ -43,22 +63,28 @@ pub trait NonEmptyArrayExt<T> {
 ///
 /// # Examples
 ///
-/// Use non-zero length arrays anywhere a [`IntoNonEmptyIterator`] is expected.
+/// Use non-zero length arrays anywhere an [`IntoNonEmptyIterator`] is expected.
+///
 /// ```
-/// # use nonempty_collections::*;
-/// # use std::num::NonZeroUsize;
-/// is_one([0]);
-/// fn is_one<T>(iter: impl IntoNonEmptyIterator<Item = T>){
+/// use nonempty_collections::*;
+/// use std::num::NonZeroUsize;
+///
+/// fn is_one<T>(iter: impl IntoNonEmptyIterator<Item = T>) {
 ///     assert_eq!(NonZeroUsize::MIN, iter.into_nonempty_iter().count());
 /// }
-/// ```
-/// Only compiles for non-empty arrays:
-/// ```compile_fail
-/// # use nonempty_collections::*;
-/// is_one([]); // doesn't compile because it is empty
-/// fn is_one(iter: impl IntoNonEmptyIterator<Item = usize>){}
+///
+/// is_one([0]);
 /// ```
 ///
+/// Only compiles for non-empty arrays:
+///
+/// ```compile_fail
+/// use nonempty_collections::*;
+///
+/// fn is_one(iter: impl IntoNonEmptyIterator<Item = usize>) {}
+///
+/// is_one([]); // Doesn't compile because it is empty.
+/// ```
 pub struct ArrayNonEmptyIterator<T, const C: usize> {
     iter: core::array::IntoIter<T, C>,
 }
@@ -78,6 +104,9 @@ impl<T, const C: usize> NonEmptyIterator for ArrayNonEmptyIterator<T, C> {
     }
 }
 
+// NOTE 2024-04-05 This must never be implemented for 0.
+//
+// Also, happy birthday Dad.
 impl_nonempty_iter_for_arrays!(
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
     27, 28, 29, 30, 31, 32
@@ -102,12 +131,13 @@ macro_rules! impl_nonempty_iter_for_arrays {
 
             impl<T> NonEmptyArrayExt<T> for [T; $i] {
                 fn as_nonempty_slice(&self) -> crate::NESlice<'_, T> {
-                    // This should never panic because a slice with length > 0 is non-empty by definition
+                    // This should never panic because a slice with length > 0
+                    // is non-empty by definition.
                     crate::NESlice::from_slice(self).unwrap()
                 }
 
                 fn nonzero_len(&self) -> NonZeroUsize {
-                    // This should be fine because $i is always > 0
+                    // This should be fine because $i is always > 0.
                     unsafe { NonZeroUsize::new_unchecked($i) }
                 }
 
@@ -115,7 +145,8 @@ macro_rules! impl_nonempty_iter_for_arrays {
                 where
                     T: Clone
                 {
-                    // This should never panic because a slice with length > 0 is non-empty by definition
+                    // This should never panic because a slice with length > 0
+                    // is non-empty by definition.
                     crate::NEVec::from_slice(self).unwrap()
                 }
             }

--- a/src/array.rs
+++ b/src/array.rs
@@ -39,11 +39,6 @@ pub trait NonEmptyArrayExt<T> {
         T: Clone;
 }
 
-impl_nonempty_iter_for_arrays!(
-    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32
-);
-
 /// Non-empty iterator for arrays with length > 0.
 ///
 /// # Examples
@@ -82,6 +77,11 @@ impl<T, const C: usize> NonEmptyIterator for ArrayNonEmptyIterator<T, C> {
         self.iter.next()
     }
 }
+
+impl_nonempty_iter_for_arrays!(
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+    27, 28, 29, 30, 31, 32
+);
 
 #[doc(hidden)]
 #[macro_export]

--- a/src/array.rs
+++ b/src/array.rs
@@ -40,11 +40,11 @@ use crate::NonEmptyIterator;
 /// assert_eq!(NonZeroUsize::MIN, [1].nonzero_len());
 /// ```
 ///
-/// Copy into a non-empty vec:
+/// Convert array into a non-empty vec:
 ///
 /// ```
 /// # use nonempty_collections::*;
-/// assert_eq!(nev![4], [4].to_nonempty_vec());
+/// assert_eq!(nev![4], [4].into_nonempty_vec());
 /// ```
 pub trait NonEmptyArrayExt<T> {
     /// Create a `NESlice` that borrows the contents of `self`.
@@ -53,10 +53,8 @@ pub trait NonEmptyArrayExt<T> {
     /// Returns the length of this array as a [`NonZeroUsize`].
     fn nonzero_len(&self) -> NonZeroUsize;
 
-    /// Copies `self` into a new [`crate::NEVec`].
-    fn to_nonempty_vec(&self) -> crate::NEVec<T>
-    where
-        T: Clone;
+    /// Moves `self` into a new [`crate::NEVec`].
+    fn into_nonempty_vec(self) -> crate::NEVec<T>;
 }
 
 /// Non-empty iterator for arrays with length > 0.
@@ -141,13 +139,8 @@ macro_rules! impl_nonempty_iter_for_arrays {
                     unsafe { NonZeroUsize::new_unchecked($i) }
                 }
 
-                fn to_nonempty_vec(&self) -> crate::NEVec<T>
-                where
-                    T: Clone
-                {
-                    // This should never panic because a slice with length > 0
-                    // is non-empty by definition.
-                    crate::NEVec::from_slice(self).unwrap()
+                fn into_nonempty_vec(self) -> crate::NEVec<T> {
+                    self.into_nonempty_iter().collect()
                 }
             }
         )+

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,0 +1,124 @@
+//! Extends non-zero length arrays with conversion methods to non-empty collections.
+
+use std::num::NonZeroUsize;
+
+use crate::impl_nonempty_iter_for_arrays;
+use crate::IntoNonEmptyIterator;
+use crate::NonEmptyIterator;
+
+/// Provides extension methods for non-empty arrays.
+///
+/// # Examples
+///
+/// Create a non-empty slice of an array:
+/// ```
+/// # use nonempty_collections::*;
+/// assert_eq!(NESlice::new(&1, &[2]), [1, 2].as_nonempty_slice());
+/// ```
+/// Get the length of an array as a [`NonZeroUsize`]:
+/// ```
+/// # use nonempty_collections::NonEmptyArrayExt;
+/// # use std::num::NonZeroUsize;
+/// assert_eq!(NonZeroUsize::MIN, [1].nonzero_len());
+/// ```
+/// Copy into a non-empty vec:
+/// ```
+/// # use nonempty_collections::*;
+/// assert_eq!(nev![4], [4].to_nonempty_vec());
+/// ```
+pub trait NonEmptyArrayExt<T> {
+    /// Create a `NESlice` that borrows the contents of `self`.
+    fn as_nonempty_slice(&self) -> crate::NESlice<'_, T>;
+
+    /// Returns the length of this array as a [`NonZeroUsize`].
+    fn nonzero_len(&self) -> NonZeroUsize;
+
+    /// Copies `self` into a new [`NEVec`].
+    fn to_nonempty_vec(&self) -> crate::NEVec<T>
+    where
+        T: Clone;
+}
+
+impl_nonempty_iter_for_arrays!(
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+    27, 28, 29, 30, 31, 32
+);
+
+/// Non-empty iterator for arrays with length > 0.
+///
+/// # Examples
+///
+/// Use non-zero length arrays anywhere a [`IntoNonEmptyIterator`] is expected.
+/// ```
+/// # use nonempty_collections::*;
+/// # use std::num::NonZeroUsize;
+/// is_one([0]);
+/// fn is_one<T>(iter: impl IntoNonEmptyIterator<Item = T>){
+///     assert_eq!(NonZeroUsize::MIN, iter.into_nonempty_iter().count());
+/// }
+/// ```
+/// Only compiles for non-empty arrays:
+/// ```compile_fail
+/// # use nonempty_collections::*;
+/// is_one([]); // doesn't compile because it is empty
+/// fn is_one(iter: impl IntoNonEmptyIterator<Item = usize>){}
+/// ```
+///
+pub struct ArrayNonEmptyIterator<T, const C: usize> {
+    iter: core::array::IntoIter<T, C>,
+}
+
+impl<T, const C: usize> NonEmptyIterator for ArrayNonEmptyIterator<T, C> {
+    type Item = T;
+
+    type IntoIter = core::array::IntoIter<T, C>;
+
+    fn first(self) -> (Self::Item, Self::IntoIter) {
+        let mut iter = self.iter.into_iter();
+        (iter.next().unwrap(), iter)
+    }
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_nonempty_iter_for_arrays {
+    ($($i:literal),+ $(,)?) => {
+        $(
+            impl<T> IntoNonEmptyIterator for [T; $i] {
+                type Item = T;
+
+                type IntoIter = ArrayNonEmptyIterator<T, $i>;
+
+                fn into_nonempty_iter(self) -> Self::IntoIter {
+                    ArrayNonEmptyIterator {
+                        iter: self.into_iter(),
+                    }
+                }
+            }
+
+            impl<T> NonEmptyArrayExt<T> for [T; $i] {
+                fn as_nonempty_slice(&self) -> crate::NESlice<'_, T> {
+                    // This should never panic because a slice with length > 0 is non-empty by definition
+                    crate::NESlice::from_slice(self).unwrap()
+                }
+
+                fn nonzero_len(&self) -> NonZeroUsize {
+                    // This should be fine because $i is always > 0
+                    unsafe { NonZeroUsize::new_unchecked($i) }
+                }
+
+                fn to_nonempty_vec(&self) -> crate::NEVec<T>
+                where
+                    T: Clone
+                {
+                    // This should never panic because a slice with length > 0 is non-empty by definition
+                    crate::NEVec::from_slice(self).unwrap()
+                }
+            }
+        )+
+    };
+}

--- a/src/array.rs
+++ b/src/array.rs
@@ -122,3 +122,24 @@ macro_rules! impl_nonempty_iter_for_arrays {
         )+
     };
 }
+
+#[cfg(test)]
+mod test {
+    use crate::IntoNonEmptyIterator;
+    use crate::NonEmptyIterator;
+
+    #[test]
+    fn test_iter() {
+        let iter = [1, 2, 3, 4].into_nonempty_iter();
+        let (first, rest) = iter.first();
+        assert_eq!(1, first);
+        assert_eq!(vec![2, 3, 4], rest.into_iter().collect::<Vec<_>>());
+
+        let iter = [1].into_nonempty_iter();
+        let (first, rest) = iter.first();
+        assert_eq!(1, first);
+        assert_eq!(0, rest.into_iter().count());
+
+        assert_eq!(33, [1, -2, 33, 4].into_nonempty_iter().max());
+    }
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,5 +1,6 @@
 //! Non-empty iterators.
 
+use crate::impl_nonempty_iter_for_arrays;
 use crate::NEVec;
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -1342,5 +1343,63 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
+    }
+}
+
+
+impl_nonempty_iter_for_arrays!(
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+    27, 28, 29, 30, 31, 32
+);
+
+#[macro_export]
+macro_rules! impl_nonempty_iter_for_arrays {
+    ($($i:literal),+ $(,)?) => {
+        $(
+            impl<T> IntoNonEmptyIterator for [T; $i] {
+                type Item = T;
+
+                type IntoIter = ArrayNonEmptyIterator<T, $i>;
+
+                fn into_nonempty_iter(self) -> Self::IntoIter {
+                    ArrayNonEmptyIterator {
+                        iter: self.into_iter(),
+                    }
+                }
+            }
+        )+
+    };
+}
+
+pub struct ArrayNonEmptyIterator<T, const C: usize> {
+    iter: core::array::IntoIter<T, C>,
+}
+
+impl<T, const C: usize> NonEmptyIterator for ArrayNonEmptyIterator<T, C> {
+    type Item = T;
+
+    type IntoIter = core::array::IntoIter<T, C>;
+
+    fn first(self) -> (Self::Item, Self::IntoIter) {
+        let mut iter = self.iter.into_iter();
+        (iter.next().unwrap(), iter)
+    }
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_array_macro() {
+        receive([0]);
+        fn receive(x: impl IntoNonEmptyIterator<Item = usize>) {
+            let c = x.into_nonempty_iter().count();
+            println!("{c:?}");
+        }
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,6 +1,5 @@
 //! Non-empty iterators.
 
-use crate::impl_nonempty_iter_for_arrays;
 use crate::NEVec;
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -1343,63 +1342,5 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
-    }
-}
-
-
-impl_nonempty_iter_for_arrays!(
-    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32
-);
-
-#[macro_export]
-macro_rules! impl_nonempty_iter_for_arrays {
-    ($($i:literal),+ $(,)?) => {
-        $(
-            impl<T> IntoNonEmptyIterator for [T; $i] {
-                type Item = T;
-
-                type IntoIter = ArrayNonEmptyIterator<T, $i>;
-
-                fn into_nonempty_iter(self) -> Self::IntoIter {
-                    ArrayNonEmptyIterator {
-                        iter: self.into_iter(),
-                    }
-                }
-            }
-        )+
-    };
-}
-
-pub struct ArrayNonEmptyIterator<T, const C: usize> {
-    iter: core::array::IntoIter<T, C>,
-}
-
-impl<T, const C: usize> NonEmptyIterator for ArrayNonEmptyIterator<T, C> {
-    type Item = T;
-
-    type IntoIter = core::array::IntoIter<T, C>;
-
-    fn first(self) -> (Self::Item, Self::IntoIter) {
-        let mut iter = self.iter.into_iter();
-        (iter.next().unwrap(), iter)
-    }
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_array_macro() {
-        receive([0]);
-        fn receive(x: impl IntoNonEmptyIterator<Item = usize>) {
-            let c = x.into_nonempty_iter().count();
-            println!("{c:?}");
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,21 @@
 //! Consider also [`IteratorExt::to_nonempty_iter`] for converting any given
 //! [`Iterator`] into a non-empty one, if it contains at least one item.
 //!
+//! # Arrays
+//!
+//! Since fixed-size arrays are by definition already not empty, they aren't
+//! given a special wrapper type like [`crate::NEVec`]. Instead, we enable them
+//! to be easily iterated over in a compatible way:
+//!
+//! ```
+//! use nonempty_collections::*;
+//!
+//! let a: [u32; 4] = [1, 2, 3, 4];
+//! let v: NEVec<_> = a.into_nonempty_iter().map(|n| n + 1).collect();
+//! assert_eq!(nev![2, 3, 4, 5], v);
+//! ```
+//! See [`NonEmptyArrayExt`] for more conversions.
+//!
 //! # Caveats
 //!
 //! Since `NEVec`, `NEMap`, and `NESet` must have a least one element, it is not

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@
 
 #![warn(missing_docs)]
 
+pub mod array;
 #[cfg(feature = "indexmap")]
 pub mod index_map;
 pub mod iter;
@@ -113,6 +114,8 @@ pub mod set;
 pub mod slice;
 pub mod vector;
 
+pub use array::ArrayNonEmptyIterator;
+pub use array::NonEmptyArrayExt;
 #[cfg(feature = "indexmap")]
 pub use index_map::NEIndexMap;
 pub use iter::FromNonEmptyIterator;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -44,7 +44,8 @@ impl<'a, T> NESlice<'a, T> {
     }
 
     /// No, this slice is not empty.
-    pub fn is_empty(&self) -> bool {
+    #[deprecated(note = "A NESlice is never empty.")]
+    pub const fn is_empty(&self) -> bool {
         false
     }
 


### PR DESCRIPTION
Adds some convenience conversions to non-empty arrays up to length 32. This number is arbitrarily chosen but there seems to be some precedence such as that the `Default` trait [is implemented for arrays up to length 32](https://doc.rust-lang.org/src/core/array/mod.rs.html#452).