### PR TITLE
Slow performance of `NEVec` and `NonEmptyIterator`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ indexmap = { version = "2.2.5", optional = true }
 
 [dev-dependencies]
 serde_json = "1"
+divan = "0.1.14"
+
+[[bench]]
+name = "vec"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/benches/vec.rs
+++ b/benches/vec.rs
@@ -1,8 +1,8 @@
 use divan::black_box;
 use divan::Bencher;
-use nonempty_collections::FromNonEmptyIterator;
+use nonempty_collections::vec2::NEVec2;
+use nonempty_collections::vec2::NonEmptyIterator2;
 use nonempty_collections::IntoIteratorExt;
-use nonempty_collections::IteratorExt;
 use nonempty_collections::NEVec;
 use nonempty_collections::NonEmptyIterator;
 
@@ -12,102 +12,46 @@ fn main() {
 }
 
 const LENS: &[usize] = &[1, 8, 64, 1024];
+const SAMPLE_SIZE: u32 = 10000;
 
-// Register a `fibonacci` function and benchmark it over multiple cases.
-// #[divan::bench(args = [1, 2, 4, 8, 16, 32])]
-// fn fibonacci(n: u64) -> u64 {
-//     if n <= 1 {
-//         1
-//     } else {
-//         fibonacci(n - 2) + fibonacci(n - 1)
-//     }
-// }
-
-// #[divan::bench(
-//     types = [
-//         Vec<i32>,
-//         NEVec<i32>,
-//     ],
-//     args = LENS,
-// )]
-// fn from_iter<T: FromIterator<i32>>(bencher: Bencher, len: usize) {
-//     bencher.counter(len).bench(|| collect_nums::<T>(len))
-// }
-
-#[divan::bench(args = LENS)]
-fn collect_vec(bencher: Bencher, len: usize) {
-    bencher.counter(len).bench(|| collect_nums::<Vec<_>>(len))
-}
-
-#[divan::bench(args = LENS)]
-fn collect_nevec(bencher: Bencher, len: usize) {
-    bencher
-        .counter(len)
-        .bench(|| ne_collect_nums::<NEVec<_>>(len))
-}
-
-pub fn collect_nums<T: FromIterator<i32>>(n: usize) -> T {
-    black_box(0..(n as i32)).collect()
-}
-
-pub fn ne_collect_nums<T: FromNonEmptyIterator<i32>>(n: usize) -> T {
-    black_box(0..(n as i32))
-        .to_nonempty_iter()
-        .unwrap()
-        .collect()
-}
-
-#[divan::bench]
-fn contains_vec(bencher: Bencher) {
-    let vec = (0..64).collect::<Vec<_>>();
+#[divan::bench(args = LENS, sample_size = SAMPLE_SIZE)]
+fn contains_vec(bencher: Bencher, len: usize) {
+    let vec = (0..len).collect::<Vec<_>>();
     bencher.bench(|| black_box(vec.contains(&32)))
 }
 
-#[divan::bench]
-fn contains_nevec(bencher: Bencher) {
-    let vec = (0..64)
+#[divan::bench(args = LENS, sample_size = SAMPLE_SIZE)]
+fn contains_nevec(bencher: Bencher, len: usize) {
+    let vec = (0..len)
         .try_into_nonempty_iter()
         .unwrap()
         .collect::<NEVec<_>>();
     bencher.bench(|| black_box(vec.contains(&32)))
 }
 
-const LOOKUPS: [usize; 7] = [7, 19, 32, 46, 64, 0, 53];
-
-#[divan::bench]
-fn get_vec(bencher: Bencher) {
-    let vec = (0..64).collect::<Vec<_>>();
-    bencher.bench(|| {
-        for i in LOOKUPS {
-            black_box(vec.get(i));
-        }
-    })
+#[divan::bench(args = LENS, sample_size = SAMPLE_SIZE)]
+fn contains_nevec2(bencher: Bencher, len: usize) {
+    let vec = NEVec2::try_new((0..len).collect::<Vec<_>>()).unwrap();
+    bencher.bench(|| black_box(vec.contains(&32)))
 }
 
-#[divan::bench]
-fn get_nevec(bencher: Bencher) {
-    let vec = (0..64)
-        .try_into_nonempty_iter()
-        .unwrap()
-        .collect::<NEVec<_>>();
-    bencher.bench(|| {
-        for i in LOOKUPS {
-            black_box(vec.get(i));
-        }
-    })
-}
-
-#[divan::bench]
-fn map_vec(bencher: Bencher) {
-    let vec = (0..64).collect::<Vec<_>>();
+#[divan::bench(args = LENS, sample_size = SAMPLE_SIZE)]
+fn map_vec(bencher: Bencher, len: usize) {
+    let vec = (0..len).collect::<Vec<_>>();
     bencher.bench(|| black_box(vec.iter().map(|i| i + 7).collect::<Vec<_>>()))
 }
 
-#[divan::bench]
-fn map_nevec(bencher: Bencher) {
-    let vec = (0..64)
+#[divan::bench(args = LENS, sample_size = SAMPLE_SIZE)]
+fn map_nevec(bencher: Bencher, len: usize) {
+    let vec = (0..len)
         .try_into_nonempty_iter()
         .unwrap()
         .collect::<NEVec<_>>();
     bencher.bench(|| black_box(vec.iter().map(|i| i + 7).collect::<NEVec<_>>()))
+}
+
+#[divan::bench(args = LENS, sample_size = SAMPLE_SIZE)]
+fn map_nevec2(bencher: Bencher, len: usize) {
+    let vec = NEVec2::try_new((0..len).collect::<Vec<_>>()).unwrap();
+    bencher.bench(|| black_box(vec.iter().map(|i| i + 7).collect::<NEVec2<_>>()))
 }

--- a/benches/vec.rs
+++ b/benches/vec.rs
@@ -96,3 +96,18 @@ fn get_nevec(bencher: Bencher) {
         }
     })
 }
+
+#[divan::bench]
+fn map_vec(bencher: Bencher) {
+    let vec = (0..64).collect::<Vec<_>>();
+    bencher.bench(|| black_box(vec.iter().map(|i| i + 7).collect::<Vec<_>>()))
+}
+
+#[divan::bench]
+fn map_nevec(bencher: Bencher) {
+    let vec = (0..64)
+        .try_into_nonempty_iter()
+        .unwrap()
+        .collect::<NEVec<_>>();
+    bencher.bench(|| black_box(vec.iter().map(|i| i + 7).collect::<NEVec<_>>()))
+}

--- a/benches/vec.rs
+++ b/benches/vec.rs
@@ -1,0 +1,98 @@
+use divan::black_box;
+use divan::Bencher;
+use nonempty_collections::FromNonEmptyIterator;
+use nonempty_collections::IntoIteratorExt;
+use nonempty_collections::IteratorExt;
+use nonempty_collections::NEVec;
+use nonempty_collections::NonEmptyIterator;
+
+fn main() {
+    // Run registered benchmarks.
+    divan::main();
+}
+
+const LENS: &[usize] = &[1, 8, 64, 1024];
+
+// Register a `fibonacci` function and benchmark it over multiple cases.
+// #[divan::bench(args = [1, 2, 4, 8, 16, 32])]
+// fn fibonacci(n: u64) -> u64 {
+//     if n <= 1 {
+//         1
+//     } else {
+//         fibonacci(n - 2) + fibonacci(n - 1)
+//     }
+// }
+
+// #[divan::bench(
+//     types = [
+//         Vec<i32>,
+//         NEVec<i32>,
+//     ],
+//     args = LENS,
+// )]
+// fn from_iter<T: FromIterator<i32>>(bencher: Bencher, len: usize) {
+//     bencher.counter(len).bench(|| collect_nums::<T>(len))
+// }
+
+#[divan::bench(args = LENS)]
+fn collect_vec(bencher: Bencher, len: usize) {
+    bencher.counter(len).bench(|| collect_nums::<Vec<_>>(len))
+}
+
+#[divan::bench(args = LENS)]
+fn collect_nevec(bencher: Bencher, len: usize) {
+    bencher
+        .counter(len)
+        .bench(|| ne_collect_nums::<NEVec<_>>(len))
+}
+
+pub fn collect_nums<T: FromIterator<i32>>(n: usize) -> T {
+    black_box(0..(n as i32)).collect()
+}
+
+pub fn ne_collect_nums<T: FromNonEmptyIterator<i32>>(n: usize) -> T {
+    black_box(0..(n as i32))
+        .to_nonempty_iter()
+        .unwrap()
+        .collect()
+}
+
+#[divan::bench]
+fn contains_vec(bencher: Bencher) {
+    let vec = (0..64).collect::<Vec<_>>();
+    bencher.bench(|| black_box(vec.contains(&32)))
+}
+
+#[divan::bench]
+fn contains_nevec(bencher: Bencher) {
+    let vec = (0..64)
+        .try_into_nonempty_iter()
+        .unwrap()
+        .collect::<NEVec<_>>();
+    bencher.bench(|| black_box(vec.contains(&32)))
+}
+
+const LOOKUPS: [usize; 7] = [7, 19, 32, 46, 64, 0, 53];
+
+#[divan::bench]
+fn get_vec(bencher: Bencher) {
+    let vec = (0..64).collect::<Vec<_>>();
+    bencher.bench(|| {
+        for i in LOOKUPS {
+            black_box(vec.get(i));
+        }
+    })
+}
+
+#[divan::bench]
+fn get_nevec(bencher: Bencher) {
+    let vec = (0..64)
+        .try_into_nonempty_iter()
+        .unwrap()
+        .collect::<NEVec<_>>();
+    bencher.bench(|| {
+        for i in LOOKUPS {
+            black_box(vec.get(i));
+        }
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ pub mod map;
 pub mod set;
 pub mod slice;
 pub mod vector;
+pub mod vec2;
 
 #[cfg(feature = "indexmap")]
 pub use index_map::NEIndexMap;

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -1,0 +1,152 @@
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NEVec2<T> {
+    inner: Vec<T>,
+}
+
+impl<T> NEVec2<T> {
+    pub fn new(head: T) -> Self {
+        NEVec2 { inner: vec![head] }
+    }
+
+    pub fn try_new(vec: Vec<T>) -> Option<Self> {
+        if vec.is_empty() {
+            return None;
+        }
+        Some(NEVec2 { inner: vec })
+    }
+
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter {
+            inner: self.inner.iter(),
+        }
+    }
+
+    pub fn contains(&self, x: &T) -> bool
+    where
+        T: PartialEq,
+    {
+        self.inner.contains(x)
+    }
+}
+
+pub trait NonEmptyIterator2: IntoIterator {
+    fn next(self) -> (Self::Item, Self::IntoIter);
+
+    #[inline]
+    fn map<U, F>(self, f: F) -> Map<Self, F>
+    where
+        Self: Sized,
+        F: FnMut(Self::Item) -> U,
+    {
+        Map { iter: self, f }
+    }
+
+    fn collect<B>(self) -> B
+    where
+        Self: Sized,
+        B: FromNonEmptyIterator2<Self::Item>,
+    {
+        FromNonEmptyIterator2::from_nonempty_iter(self)
+    }
+}
+
+pub struct Iter<'a, T> {
+    inner: std::slice::Iter<'a, T>,
+}
+
+impl<'a, T> IntoIterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner
+    }
+}
+
+impl<'a, T> NonEmptyIterator2 for Iter<'a, T> {
+    fn next(mut self) -> (Self::Item, Self::IntoIter) {
+        (self.inner.next().unwrap(), self.inner)
+    }
+}
+
+pub struct Map<I, F> {
+    iter: I,
+    f: F,
+}
+
+impl<U, I, F> IntoIterator for Map<I, F>
+where
+    I: NonEmptyIterator2,
+    F: FnMut(I::Item) -> U,
+{
+    type Item = U;
+
+    type IntoIter = std::iter::Map<<I::IntoIter as IntoIterator>::IntoIter, F>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter.into_iter().map(self.f)
+    }
+}
+
+impl<U, I, F> NonEmptyIterator2 for Map<I, F>
+where
+    I: NonEmptyIterator2,
+    F: FnMut(I::Item) -> U,
+{
+    fn next(self) -> (Self::Item, Self::IntoIter) {
+        let mut fun = self.f;
+
+        let (first, rest) = self.iter.next();
+
+        (fun(first), rest.into_iter().map(fun))
+    }
+}
+
+pub trait FromNonEmptyIterator2<T>: Sized {
+    fn from_nonempty_iter<I>(iter: I) -> Self
+    where
+        I: IntoNonEmptyIterator2<Item = T>;
+}
+
+impl<T> FromNonEmptyIterator2<T> for Vec<T> {
+    fn from_nonempty_iter<I>(iter: I) -> Self
+    where
+        I: IntoNonEmptyIterator2<Item = T>,
+    {
+        let (head, rest) = iter.into_nonempty_iter().next();
+
+        let mut v = vec![head];
+        v.extend(rest);
+        v
+    }
+}
+
+pub trait IntoNonEmptyIterator2 {
+    type Item;
+
+    type IntoIter: NonEmptyIterator2<Item = Self::Item>;
+
+    fn into_nonempty_iter(self) -> Self::IntoIter;
+}
+
+impl<I: NonEmptyIterator2> IntoNonEmptyIterator2 for I {
+    type Item = I::Item;
+
+    type IntoIter = I;
+
+    fn into_nonempty_iter(self) -> Self::IntoIter {
+        self
+    }
+}
+
+impl<T> FromNonEmptyIterator2<T> for NEVec2<T> {
+    fn from_nonempty_iter<I>(iter: I) -> Self
+    where
+        I: IntoNonEmptyIterator2<Item = T>,
+    {
+        NEVec2 {
+            inner: iter.into_nonempty_iter().into_iter().collect(),
+        }
+    }
+}


### PR DESCRIPTION
# Problem
As part of my work we do regular benchmarks and I found that replacing `Vec` with `NEVec` somewhere caused a noticable slowdown. I started investigating and created some micro benchmarks. I found that `NEVec` is considerably slower than `Vec` which seems to be related to how the non-empty iterator is implemented. 

# Solution
I created an alternative implementation called `NEVec2` that only implements a couple methods for benchmarking. `NEVec2` is a simple wrapper for `Vec` that can, by proper encapsulation guarantee non-emptiness. For the API of `NonEmptyIterator2` I went for the design that I also proposed in https://github.com/fosskers/nonempty-collections/pull/16.  Based on my (limited) experience with this new design I think that it would allow to make a lot of code much simpler because it can forward a most of the calls directly to the underlying `Vec` while still upholding the non-empty guarantee. I believe that this is also what keeps the performance on par with the underlying `Vec`.

# Benchmark results

Results obtained with `cargo bench`:
```
vec                 fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ contains_nevec                 │               │               │               │         │
│  ├─ 1             1.304 ns      │ 3.475 ns      │ 1.321 ns      │ 1.43 ns       │ 100     │ 1000000
│  ├─ 8             8.483 ns      │ 13.34 ns      │ 9.462 ns      │ 9.516 ns      │ 100     │ 1000000
│  ├─ 64            23.59 ns      │ 31.54 ns      │ 25.65 ns      │ 25.77 ns      │ 100     │ 1000000
│  ╰─ 1024          21.17 ns      │ 25.84 ns      │ 22.21 ns      │ 22.36 ns      │ 100     │ 1000000
├─ contains_nevec2                │               │               │               │         │
│  ├─ 1             0.425 ns      │ 2.025 ns      │ 0.458 ns      │ 0.501 ns      │ 100     │ 1000000
│  ├─ 8             3.208 ns      │ 5.229 ns      │ 3.216 ns      │ 3.319 ns      │ 100     │ 1000000
│  ├─ 64            10.64 ns      │ 15.37 ns      │ 10.83 ns      │ 11.12 ns      │ 100     │ 1000000
│  ╰─ 1024          10.64 ns      │ 13.09 ns      │ 10.99 ns      │ 11.09 ns      │ 100     │ 1000000
├─ contains_vec                   │               │               │               │         │
│  ├─ 1             0.421 ns      │ 0.708 ns      │ 0.454 ns      │ 0.464 ns      │ 100     │ 1000000
│  ├─ 8             3.212 ns      │ 6.321 ns      │ 3.329 ns      │ 3.392 ns      │ 100     │ 1000000
│  ├─ 64            10.64 ns      │ 13.61 ns      │ 10.67 ns      │ 10.89 ns      │ 100     │ 1000000
│  ╰─ 1024          10.63 ns      │ 14.1 ns       │ 10.65 ns      │ 10.92 ns      │ 100     │ 1000000
├─ map_nevec                      │               │               │               │         │
│  ├─ 1             3.646 ns      │ 6.421 ns      │ 3.783 ns      │ 3.888 ns      │ 100     │ 1000000
│  ├─ 8             25.1 ns       │ 34.77 ns      │ 26.78 ns      │ 27.17 ns      │ 100     │ 1000000
│  ├─ 64            80.47 ns      │ 122.1 ns      │ 90.51 ns      │ 90.89 ns      │ 100     │ 1000000
│  ╰─ 1024          1.392 µs      │ 1.831 µs      │ 1.581 µs      │ 1.585 µs      │ 100     │ 1000000
├─ map_nevec2                     │               │               │               │         │
│  ├─ 1             18.82 ns      │ 25.47 ns      │ 20.02 ns      │ 20.26 ns      │ 100     │ 1000000
│  ├─ 8             21.99 ns      │ 27.78 ns      │ 22.57 ns      │ 23.04 ns      │ 100     │ 1000000
│  ├─ 64            41.69 ns      │ 76.03 ns      │ 48.86 ns      │ 50.1 ns       │ 100     │ 1000000
│  ╰─ 1024          666.8 ns      │ 866.3 ns      │ 716.6 ns      │ 721.5 ns      │ 100     │ 1000000
╰─ map_vec                        │               │               │               │         │
   ├─ 1             19.75 ns      │ 26.01 ns      │ 20.05 ns      │ 20.37 ns      │ 100     │ 1000000
   ├─ 8             21.87 ns      │ 29.22 ns      │ 22.49 ns      │ 22.88 ns      │ 100     │ 1000000
   ├─ 64            45.82 ns      │ 67.69 ns      │ 52.06 ns      │ 52.81 ns      │ 100     │ 1000000
   ╰─ 1024          656.8 ns      │ 862.5 ns      │ 717.3 ns      │ 737.3 ns      │ 100     │ 1000000
```
As can be seen above, the old `NEVec` performs up to 2x slower than `NEVec2` and plain `Vec`. The exception is when the data size is 1. This is because `NEVec` keeps the first element in a local variable which means it is on the stack and not on the heap.

I expect that similar performance drawbacks exist for the other datastructures.

Note that these numbers will change from run to run and from machine to machine. The conclusions, however, seem to be consistent.

# Moving forward

I hope you are convinced that this warrants a change in the design of the crate. 

For the future the `vec2.rs` file can be entirely discarded as I just created it for benchmarking purposes. I think it makes sense to adapt the internals of the datastructures and iterators such it works similar as in `vec2.rs`. Before I start on any of that I would like to hear your opinion of course 😄 

