### PR TITLE
add `iter_mut()` for `NEVec`, `NEMap`, and `NEIndexMap`

### DIFF
--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -69,11 +69,19 @@ impl<K, V, S> NEIndexMap<K, V, S> {
         self.inner.hasher()
     }
 
-    /// Returns a regular iterator over the values in this non-empty index map.
+    /// Returns a regular iterator over the entries in this non-empty index map.
     ///
     /// For a `NonEmptyIterator` see `Self::nonempty_iter()`.
     pub fn iter(&self) -> indexmap::map::Iter<'_, K, V> {
         self.inner.iter()
+    }
+
+    /// Returns a regular mutable iterator over the entries in this non-empty
+    /// index map.
+    ///
+    /// For a `NonEmptyIterator` see `Self::nonempty_iter_mut()`.
+    pub fn iter_mut(&mut self) -> indexmap::map::IterMut<'_, K, V> {
+        self.inner.iter_mut()
     }
 
     /// An iterator visiting all elements in their order.
@@ -463,6 +471,16 @@ impl<'a, K, V, S> IntoIterator for &'a NEIndexMap<K, V, S> {
     }
 }
 
+impl<'a, K, V, S> IntoIterator for &'a mut NEIndexMap<K, V, S> {
+    type Item = (&'a K, &'a mut V);
+
+    type IntoIter = indexmap::map::IterMut<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 /// ```
 /// use nonempty_collections::*;
 ///
@@ -727,5 +745,20 @@ mod test {
         let expected = format!("{:?}", indexmap! {0 => 10, 1 => 11, 2 => 12});
         let actual = format!("{:?}", ne_indexmap! {0 => 10, 1 => 11, 2 => 12});
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn iter_mut() {
+        let mut v = ne_indexmap! {"a" => 0, "b" => 1, "c" => 2};
+
+        v.iter_mut().for_each(|(_k, v)| {
+            *v += 1;
+        });
+        assert_eq!(ne_indexmap! {"a" => 1, "b" => 2, "c" => 3}, v);
+
+        for (_k, v) in &mut v {
+            *v -= 1;
+        }
+        assert_eq!(ne_indexmap! {"a" => 0, "b" => 1, "c" => 2}, v);
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -126,11 +126,19 @@ impl<K, V, S> NEMap<K, V, S> {
         self.inner.hasher()
     }
 
-    /// Returns a regular iterator over the values in this non-empty map.
+    /// Returns a regular iterator over the entries in this non-empty map.
     ///
     /// For a `NonEmptyIterator` see `Self::nonempty_iter()`.
     pub fn iter(&self) -> std::collections::hash_map::Iter<'_, K, V> {
         self.inner.iter()
+    }
+
+    /// Returns a regular mutable iterator over the entries in this non-empty
+    /// map.
+    ///
+    /// For a `NonEmptyIterator` see `Self::nonempty_iter_mut()`.
+    pub fn iter_mut(&mut self) -> std::collections::hash_map::IterMut<'_, K, V> {
+        self.inner.iter_mut()
     }
 
     /// An iterator visiting all elements in arbitrary order. The iterator
@@ -469,6 +477,16 @@ impl<'a, K, V, S> IntoIterator for &'a NEMap<K, V, S> {
     }
 }
 
+impl<'a, K, V, S> IntoIterator for &'a mut NEMap<K, V, S> {
+    type Item = (&'a K, &'a mut V);
+
+    type IntoIter = std::collections::hash_map::IterMut<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 /// ```
 /// use nonempty_collections::*;
 ///
@@ -676,6 +694,21 @@ mod test {
         assert_eq!(unsafe { NonZeroUsize::new_unchecked(2) }, map.len());
         assert_eq!('c', *map.get(&1).unwrap());
         assert_eq!('b', *map.get(&2).unwrap());
+    }
+
+    #[test]
+    fn iter_mut() {
+        let mut v = nem! {"a" => 0, "b" => 1, "c" => 2};
+
+        v.iter_mut().for_each(|(_k, v)| {
+            *v += 1;
+        });
+        assert_eq!(nem! {"a" => 1, "b" => 2, "c" => 3}, v);
+
+        for (_k, v) in &mut v {
+            *v -= 1;
+        }
+        assert_eq!(nem! {"a" => 0, "b" => 1, "c" => 2}, v);
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -235,6 +235,14 @@ impl<T> NEVec<T> {
         self.inner.iter()
     }
 
+    /// Returns a regular mutable iterator over the values in this non-empty
+    /// vector.
+    ///
+    /// For a `NonEmptyIterator` see `Self::nonempty_iter_mut()`.
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
+        self.inner.iter_mut()
+    }
+
     /// ```
     /// use nonempty_collections::*;
     ///
@@ -958,6 +966,15 @@ impl<'a, T> IntoIterator for &'a NEVec<T> {
     }
 }
 
+impl<'a, T> IntoIterator for &'a mut NEVec<T> {
+    type Item = &'a mut T;
+    type IntoIter = std::slice::IterMut<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T> std::ops::Index<usize> for NEVec<T> {
     type Output = T;
 
@@ -1148,5 +1165,21 @@ mod tests {
         n.extend(v);
 
         assert_eq!(n, nev![1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn iter_mut() {
+        let mut v = nev![0, 1, 2, 3];
+
+        v.iter_mut().for_each(|x| {
+            *x += 1;
+        });
+
+        assert_eq!(nev![1, 2, 3, 4], v);
+
+        for x in &mut v {
+            *x -= 1;
+        }
+        assert_eq!(nev![0, 1, 2, 3], v);
     }
 }


### PR DESCRIPTION
Adds `iter_mut()` which improves parity with the possibly-empty counterparts of the respective non-empty collections.