### PR TITLE
NEVec, NEIndexMap: use `unwrap_unchecked` in more methods

### DIFF
--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -164,17 +164,17 @@ impl<K, V, S> NEIndexMap<K, V, S> {
     }
 
     /// Get the first element. Never fails.
-    #[allow(clippy::missing_panics_doc)] // the invariant of NEIndexMap is that its non-empty
     #[must_use]
     pub fn first(&self) -> (&K, &V) {
-        self.inner.first().unwrap()
+        // SAFETY: the invariant of NEIndexMap is that its non-empty
+        unsafe { self.inner.first().unwrap_unchecked() }
     }
 
     /// Get the last element. Never fails.
-    #[allow(clippy::missing_panics_doc)] // the invariant of NEIndexMap is that its non-empty
     #[must_use]
     pub fn last(&self) -> (&K, &V) {
-        self.inner.last().unwrap()
+        // SAFETY: the invariant of NEIndexMap is that its non-empty
+        unsafe { self.inner.last().unwrap_unchecked() }
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -315,16 +315,14 @@ impl<T> NEVec<T> {
 
     /// Get the last element. Never fails.
     #[must_use]
-    #[allow(clippy::missing_panics_doc)] // never fails
     pub fn last(&self) -> &T {
-        self.inner.last().unwrap()
+        unsafe { self.inner.last().unwrap_unchecked() }
     }
 
     /// Get the last element mutably.
     #[must_use]
-    #[allow(clippy::missing_panics_doc)] // never fails
     pub fn last_mut(&mut self) -> &mut T {
-        self.inner.last_mut().unwrap()
+        unsafe { self.inner.last_mut().unwrap_unchecked() }
     }
 
     /// Check whether an element is contained in the list.
@@ -505,9 +503,8 @@ impl<T> NEVec<T> {
     /// assert_eq!(v.split_first(), (&1, &[][..]));
     /// ```
     #[must_use]
-    #[allow(clippy::missing_panics_doc)] // never fails
     pub fn split_first(&self) -> (&T, &[T]) {
-        self.inner.split_first().unwrap()
+        unsafe { self.inner.split_first().unwrap_unchecked() }
     }
 
     /// Deconstruct a `NEVec` into its first, last, and


### PR DESCRIPTION
to avoid the `missing_panics_doc` lint