### PR TITLE
feat: add `AsRef` and `AsMut` impls

### DIFF
--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -397,6 +397,18 @@ where
     }
 }
 
+impl<K, V, S> AsRef<IndexMap<K, V, S>> for NEIndexMap<K, V, S> {
+    fn as_ref(&self) -> &IndexMap<K, V, S> {
+        &self.inner
+    }
+}
+
+impl<K, V, S> AsMut<IndexMap<K, V, S>> for NEIndexMap<K, V, S> {
+    fn as_mut(&mut self) -> &mut IndexMap<K, V, S> {
+        &mut self.inner
+    }
+}
+
 impl<K, V, S> PartialEq for NEIndexMap<K, V, S>
 where
     K: Eq + Hash,

--- a/src/map.rs
+++ b/src/map.rs
@@ -379,6 +379,18 @@ where
     }
 }
 
+impl<K, V, S> AsRef<HashMap<K, V, S>> for NEMap<K, V, S> {
+    fn as_ref(&self) -> &HashMap<K, V, S> {
+        &self.inner
+    }
+}
+
+impl<K, V, S> AsMut<HashMap<K, V, S>> for NEMap<K, V, S> {
+    fn as_mut(&mut self) -> &mut HashMap<K, V, S> {
+        &mut self.inner
+    }
+}
+
 impl<K, V, S> PartialEq for NEMap<K, V, S>
 where
     K: Eq + Hash,

--- a/src/set.rs
+++ b/src/set.rs
@@ -425,6 +425,18 @@ where
     }
 }
 
+impl<T, S> AsRef<HashSet<T, S>> for NESet<T, S> {
+    fn as_ref(&self) -> &HashSet<T, S> {
+        &self.inner
+    }
+}
+
+impl<T, S> AsMut<HashSet<T, S>> for NESet<T, S> {
+    fn as_mut(&mut self) -> &mut HashSet<T, S> {
+        &mut self.inner
+    }
+}
+
 impl<T, S> PartialEq for NESet<T, S>
 where
     T: Eq + Hash,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -993,6 +993,18 @@ impl<T> From<(T, Vec<T>)> for NEVec<T> {
     }
 }
 
+impl<T> AsRef<Vec<T>> for NEVec<T> {
+    fn as_ref(&self) -> &Vec<T> {
+        self.inner.as_ref()
+    }
+}
+
+impl<T> AsMut<Vec<T>> for NEVec<T> {
+    fn as_mut(&mut self) -> &mut Vec<T> {
+        self.inner.as_mut()
+    }
+}
+
 /// ```
 /// use nonempty_collections::*;
 ///


### PR DESCRIPTION
I stumbled upon the need for those when I needed to turn `&mut NEVec` into `&mut Vec`, but I went ahead and added the impls to all the other structs as well