### PR TITLE
Align NEMap's PartialEq implementation boundaries with std HashMap

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -382,7 +382,7 @@ where
 impl<K, V, S> PartialEq for NEMap<K, V, S>
 where
     K: Eq + Hash,
-    V: Eq,
+    V: PartialEq,
     S: BuildHasher,
 {
     /// This is an `O(n)` comparison of each key/value pair, one by one.


### PR DESCRIPTION
This difference makes using `NEMap` impossible in case the value does not implement `Eq` (`f32` for example) for structs serialized with `strum`. This change will make it possible.