### PR TITLE
Adds schemars support and forwards dependency features conditionally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +169,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "maplit",
+ "schemars",
  "serde",
  "serde_json",
 ]
@@ -183,6 +190,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -211,6 +238,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schemars"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+dependencies = [
+ "dyn-clone",
+ "either",
+ "indexmap",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301858a4023d78debd2353c7426dc486001bddc91ae31a76fb1f55132f7e2633"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +288,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -119,6 +122,8 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ serde = { version = "1.0", features = ["serde_derive"], optional = true }
 indexmap = { version = "2.7", optional = true }
 either = { version = "1.0", optional = true }
 itertools = { version = "0.14", optional = true, features = ["use_alloc"] }
+schemars = { version = "1.1.0", optional = true }
+
+[features]
+indexmap = ["dep:indexmap", "schemars?/indexmap2"]
+either = ["dep:either", "schemars?/either1"]
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ schemars = { version = "1.1.0", optional = true }
 [features]
 indexmap = ["dep:indexmap", "schemars?/indexmap2"]
 either = ["dep:either", "schemars?/either1"]
+serde = ["dep:serde", "indexmap?/serde", "either?/serde"]
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -134,5 +134,6 @@ contains something.
 * `indexmap`: adds [`NEIndexMap`](https://docs.rs/nonempty-collections/latest/nonempty_collections/index_map/struct.NEIndexMap.html) a non-empty [`IndexMap`](https://docs.rs/indexmap/latest/indexmap/).
 * `itertools`: adds [`NonEmptyItertools`](https://docs.rs/nonempty-collections/latest/nonempty_collections/itertools/trait.NonEmptyItertools.html) a non-empty variant of [`itertools`](https://docs.rs/itertools/latest/itertools/).
 * `either`: adds [`NEEither`](https://docs.rs/nonempty-collections/latest/nonempty_collections/either/enum.NEEither.html) a non-empty variant of `Either` from the [`either` crate](https://docs.rs/either/latest/either/).
+* `schemars`: adds [`schemars`](https://docs.rs/schemars/1/schemars/) support.
 
 <!-- cargo-rdme end -->

--- a/src/either.rs
+++ b/src/either.rs
@@ -32,6 +32,12 @@ use either::Either;
 use crate::IntoNonEmptyIterator;
 use crate::NonEmptyIterator;
 
+#[cfg(feature = "schemars")]
+use ::{
+    schemars::{JsonSchema, Schema, SchemaGenerator},
+    std::borrow::Cow,
+};
+
 /// Non-empty variant of [`either::Either`] that implements
 /// [`NonEmptyIterator`].
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -90,5 +96,20 @@ where
             NEEither::Left(left) => Either::Left(left.into_iter()),
             NEEither::Right(right) => Either::Right(right.into_iter()),
         }
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<L: JsonSchema, R: JsonSchema> JsonSchema for NEEither<L, R> {
+    fn schema_name() -> Cow<'static, str> {
+        Either::<L, R>::schema_name()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        Either::<L, R>::json_schema(generator)
+    }
+
+    fn inline_schema() -> bool {
+        Either::<L, R>::inline_schema()
     }
 }

--- a/src/either.rs
+++ b/src/either.rs
@@ -38,9 +38,13 @@ use ::{
     std::borrow::Cow,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Non-empty variant of [`either::Either`] that implements
 /// [`NonEmptyIterator`].
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum NEEither<L, R> {
     /// A value of type `L`.
     Left(L),
@@ -111,5 +115,24 @@ impl<L: JsonSchema, R: JsonSchema> JsonSchema for NEEither<L, R> {
 
     fn inline_schema() -> bool {
         Either::<L, R>::inline_schema()
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::{Either, NEEither};
+
+    #[test]
+    fn json() {
+        let ne_either: NEEither<i32, f32> = NEEither::Left(123);
+        let ne_either_json = serde_json::to_string(&ne_either).unwrap();
+        let either: Either<i32, f32> = serde_json::from_str(&ne_either_json).unwrap();
+        let either_json = serde_json::to_string(&either).unwrap();
+
+        assert_eq!(&ne_either_json, &either_json);
+
+        let ne_either_2: NEEither<i32, f32> = serde_json::from_str(&either_json).unwrap();
+
+        assert_eq!(&ne_either, &ne_either_2);
     }
 }

--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -7,15 +7,21 @@ use crate::FromNonEmptyIterator;
 use crate::IntoNonEmptyIterator;
 use crate::NonEmptyIterator;
 use crate::Singleton;
-use indexmap::indexmap;
 use indexmap::Equivalent;
 use indexmap::IndexMap;
+use indexmap::indexmap;
 use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
+
+#[cfg(feature = "schemars")]
+use ::{
+    schemars::{JsonSchema, Schema, SchemaGenerator},
+    std::borrow::Cow,
+};
 
 /// Short-hand for constructing [`NEIndexMap`] values.
 ///
@@ -736,6 +742,29 @@ where
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<K: JsonSchema, V: JsonSchema> JsonSchema for super::NEIndexMap<K, V> {
+    fn schema_name() -> Cow<'static, str> {
+        IndexMap::<K, V>::schema_name()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let mut schema = IndexMap::<K, V>::json_schema(generator);
+
+        if let Some(schema_object) = schema.as_object_mut()
+            && schema_object["type"] == "object"
+        {
+            schema_object.insert("minProperties".to_string(), 1.into());
+        }
+
+        schema
+    }
+
+    fn inline_schema() -> bool {
+        IndexMap::<K, V>::inline_schema()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -797,5 +826,21 @@ mod test {
             *v -= 1;
         }
         assert_eq!(ne_indexmap! {"a" => 0, "b" => 1, "c" => 2}, v);
+    }
+
+    #[cfg(feature = "schemars")]
+    mod schemars_tests {
+        use super::{IndexMap, NEIndexMap};
+        use schemars::schema_for;
+
+        #[test]
+        fn test_simple_schema() {
+            let actual = schema_for!(NEIndexMap<i32, i32>).to_value();
+
+            let mut expected = schema_for!(IndexMap<i32, i32>).to_value();
+            expected["minProperties"] = 1.into();
+
+            assert_eq!(expected, actual);
+        }
     }
 }

--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -4,6 +4,7 @@
 //! order.
 
 use crate::FromNonEmptyIterator;
+use crate::IntoIteratorExt;
 use crate::IntoNonEmptyIterator;
 use crate::NonEmptyIterator;
 use crate::Singleton;
@@ -22,6 +23,8 @@ use ::{
     schemars::{JsonSchema, Schema, SchemaGenerator},
     std::borrow::Cow,
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Short-hand for constructing [`NEIndexMap`] values.
 ///
@@ -57,8 +60,31 @@ macro_rules! ne_indexmap {
 /// assert_eq!(2, m.len().get());
 /// ```
 #[derive(Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Deserialize, Serialize),
+    serde(bound(
+        serialize = "K: Eq + Hash + Clone + Serialize, V: Clone + Serialize, S: Clone + BuildHasher",
+        deserialize = "K: Eq + Hash + Clone + Deserialize<'de>, V: Deserialize<'de>, S: Default + BuildHasher"
+    )),
+    serde(into = "IndexMap<K, V, S>", try_from = "IndexMap<K, V, S>")
+)]
 pub struct NEIndexMap<K, V, S = std::collections::hash_map::RandomState> {
     inner: IndexMap<K, V, S>,
+}
+
+impl<K, V, S> TryFrom<IndexMap<K, V, S>> for NEIndexMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    type Error = crate::Error;
+
+    fn try_from(map: IndexMap<K, V, S>) -> Result<Self, Self::Error> {
+        map.try_into_nonempty_iter()
+            .map(NonEmptyIterator::collect)
+            .ok_or(crate::Error::Empty)
+    }
 }
 
 impl<K, V, S> NEIndexMap<K, V, S> {
@@ -826,6 +852,28 @@ mod test {
             *v -= 1;
         }
         assert_eq!(ne_indexmap! {"a" => 0, "b" => 1, "c" => 2}, v);
+    }
+
+    #[cfg(feature = "serde")]
+    #[cfg(test)]
+    mod serde_tests {
+        use indexmap::IndexMap;
+
+        use crate::NEIndexMap;
+        use crate::ne_indexmap;
+
+        #[test]
+        fn json() {
+            let map0 = ne_indexmap![1 => 'a', 2 => 'b', 1 => 'c'];
+            let j = serde_json::to_string(&map0).unwrap();
+            let map1 = serde_json::from_str(&j).unwrap();
+            assert_eq!(map0, map1);
+
+            let empty: IndexMap<usize, char> = IndexMap::new();
+            let j = serde_json::to_string(&empty).unwrap();
+            let bad = serde_json::from_str::<NEIndexMap<usize, char>>(&j);
+            assert!(bad.is_err());
+        }
     }
 
     #[cfg(feature = "schemars")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@
 //! * `indexmap`: adds [`NEIndexMap`](crate::index_map::NEIndexMap) a non-empty [`IndexMap`](https://docs.rs/indexmap/latest/indexmap/).
 //! * `itertools`: adds [`NonEmptyItertools`](crate::itertools::NonEmptyItertools) a non-empty variant of [`itertools`](https://docs.rs/itertools/latest/itertools/).
 //! * `either`: adds [`NEEither`](crate::either::NEEither) a non-empty variant of `Either` from the [`either` crate](https://docs.rs/either/latest/either/).
+//! * `schemars`: adds [`schemars`](https://docs.rs/schemars/1/schemars/) support.
 
 pub mod array;
 pub mod iter;

--- a/src/map.rs
+++ b/src/map.rs
@@ -7,6 +7,12 @@ use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
 
+#[cfg(feature = "schemars")]
+use ::{
+    schemars::{JsonSchema, Schema, SchemaGenerator},
+    std::borrow::Cow,
+};
+
 #[cfg(feature = "serde")]
 use serde::Deserialize;
 #[cfg(feature = "serde")]
@@ -694,6 +700,29 @@ where
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<K: JsonSchema, V: JsonSchema> JsonSchema for super::NEMap<K, V> {
+    fn schema_name() -> Cow<'static, str> {
+        HashMap::<K, V>::schema_name()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let mut schema = HashMap::<K, V>::json_schema(generator);
+
+        if let Some(schema_object) = schema.as_object_mut()
+            && schema_object["type"] == "object"
+        {
+            schema_object.insert("minProperties".to_string(), 1.into());
+        }
+
+        schema
+    }
+
+    fn inline_schema() -> bool {
+        HashMap::<K, V>::inline_schema()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::num::NonZeroUsize;
@@ -756,8 +785,8 @@ mod test {
 mod serde_tests {
     use std::collections::HashMap;
 
-    use crate::nem;
     use crate::NEMap;
+    use crate::nem;
 
     #[test]
     fn json() {
@@ -770,5 +799,22 @@ mod serde_tests {
         let j = serde_json::to_string(&empty).unwrap();
         let bad = serde_json::from_str::<NEMap<usize, char>>(&j);
         assert!(bad.is_err());
+    }
+}
+
+#[cfg(feature = "schemars")]
+#[cfg(test)]
+mod schemars_tests {
+    use super::{HashMap, NEMap};
+    use schemars::schema_for;
+
+    #[test]
+    fn test_simple_schema() {
+        let actual = schema_for!(NEMap<String, i32>).to_value();
+
+        let mut expected = schema_for!(HashMap<String, i32>).to_value();
+        expected["minProperties"] = 1.into();
+
+        assert_eq!(expected, actual);
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -7,16 +7,22 @@ use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
 
+#[cfg(feature = "schemars")]
+use ::{
+    schemars::{JsonSchema, Schema, SchemaGenerator},
+    std::borrow::Cow,
+};
+
 #[cfg(feature = "serde")]
 use serde::Deserialize;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
-use crate::iter::NonEmptyIterator;
 use crate::FromNonEmptyIterator;
 use crate::IntoIteratorExt;
 use crate::IntoNonEmptyIterator;
 use crate::Singleton;
+use crate::iter::NonEmptyIterator;
 
 /// Like the [`crate::nev!`] macro, but for Sets. A nice short-hand for
 /// constructing [`NESet`] values.
@@ -689,6 +695,29 @@ where
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T: JsonSchema> JsonSchema for super::NESet<T> {
+    fn schema_name() -> Cow<'static, str> {
+        HashSet::<T>::schema_name()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let mut schema = HashSet::<T>::json_schema(generator);
+
+        if let Some(schema_object) = schema.as_object_mut()
+            && schema_object["type"] == "array"
+        {
+            schema_object.insert("minItems".to_string(), 1.into());
+        }
+
+        schema
+    }
+
+    fn inline_schema() -> bool {
+        HashSet::<T>::inline_schema()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use maplit::hashset;
@@ -713,8 +742,8 @@ mod test {
 mod serde_tests {
     use std::collections::HashSet;
 
-    use crate::nes;
     use crate::NESet;
+    use crate::nes;
 
     #[test]
     fn json() {
@@ -727,5 +756,22 @@ mod serde_tests {
         let j = serde_json::to_string(&empty).unwrap();
         let bad = serde_json::from_str::<NESet<usize>>(&j);
         assert!(bad.is_err());
+    }
+}
+
+#[cfg(feature = "schemars")]
+#[cfg(test)]
+mod schemars_tests {
+    use super::{HashSet, NESet};
+    use schemars::schema_for;
+
+    #[test]
+    fn test_simple_schema() {
+        let actual = schema_for!(NESet<i32>).to_value();
+
+        let mut expected = schema_for!(HashSet<i32>).to_value();
+        expected["minItems"] = 1.into();
+
+        assert_eq!(expected, actual);
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,15 +1,21 @@
 //! Non-empty Vectors.
 
+use crate::Singleton;
 use crate::iter::FromNonEmptyIterator;
 use crate::iter::IntoNonEmptyIterator;
 use crate::iter::NonEmptyIterator;
 use crate::slice::NEChunks;
-use crate::Singleton;
 use core::fmt;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::num::NonZeroUsize;
+
+#[cfg(feature = "schemars")]
+use ::{
+    schemars::{JsonSchema, Schema, SchemaGenerator},
+    std::borrow::Cow,
+};
 
 #[cfg(feature = "serde")]
 use serde::Deserialize;
@@ -1206,10 +1212,33 @@ impl<T> Singleton for NEVec<T> {
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T: JsonSchema> JsonSchema for NEVec<T> {
+    fn schema_name() -> Cow<'static, str> {
+        Vec::<T>::schema_name()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let mut schema = Vec::<T>::json_schema(generator);
+
+        if let Some(schema_object) = schema.as_object_mut()
+            && schema_object["type"] == "array"
+        {
+            schema_object.insert("minItems".to_string(), 1.into());
+        }
+
+        schema
+    }
+
+    fn inline_schema() -> bool {
+        Vec::<T>::inline_schema()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::nev;
     use crate::NEVec;
+    use crate::nev;
 
     #[derive(Debug, Clone, PartialEq)]
     struct Foo {
@@ -1439,5 +1468,21 @@ mod tests {
             }
         });
         assert_eq!(Ok(nev![4]), result, "only 3+1 = 4 should remain");
+    }
+
+    #[cfg(feature = "schemars")]
+    mod schemars {
+        use super::NEVec;
+        use schemars::schema_for;
+
+        #[test]
+        fn test_simple_schema() {
+            let actual = schema_for!(NEVec<i32>).to_value();
+
+            let mut expected = schema_for!(Vec<i32>).to_value();
+            expected["minItems"] = 1.into();
+
+            assert_eq!(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
This PR adds optional support for [`schemars`](https://docs.rs/schemars/latest/schemars/) through a feature flag. It also makes use of the [optional dependency feature pattern](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) to forward activation of the `serde` feature to - and `schemars`-related features for - `either` and `indexmap` when those are active as well.

Hope you like it :)