### PR TITLE
chore: upgrade itertools to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["data-structures"]
 [dependencies]
 either = { version = "1.0", optional = true }
 indexmap = { version = "2.7", optional = true }
-itertools = { version = "0.14", optional = true, features = ["use_alloc"] }
+itertools = { version = "0.15", optional = true, features = ["use_alloc"] }
 rand = { version = "0.10", optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 


### PR DESCRIPTION
cc @fosskers 

As noted in https://github.com/rust-itertools/itertools/pull/1091 - nothing special to this crate.