### PR TITLE
Add NEIndexSet based on indexmap::IndexSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +169,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "maplit",
+ "schemars",
  "serde",
  "serde_json",
 ]
@@ -183,6 +190,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -211,6 +238,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schemars"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+dependencies = [
+ "dyn-clone",
+ "either",
+ "indexmap",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301858a4023d78debd2353c7426dc486001bddc91ae31a76fb1f55132f7e2633"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +288,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -119,6 +122,8 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ serde = { version = "1.0", features = ["serde_derive"], optional = true }
 indexmap = { version = "2.7", optional = true }
 either = { version = "1.0", optional = true }
 itertools = { version = "0.14", optional = true, features = ["use_alloc"] }
+schemars = { version = "1.1.0", optional = true }
+
+[features]
+indexmap = ["dep:indexmap", "schemars?/indexmap2"]
+either = ["dep:either", "schemars?/either1"]
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ schemars = { version = "1.1.0", optional = true }
 [features]
 indexmap = ["dep:indexmap", "schemars?/indexmap2"]
 either = ["dep:either", "schemars?/either1"]
+serde = ["dep:serde", "indexmap?/serde", "either?/serde"]
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ contains something.
 ## Features
 
 * `serde`: `serde` support.
-* `indexmap`: adds [`NEIndexMap`](https://docs.rs/nonempty-collections/latest/nonempty_collections/index_map/struct.NEIndexMap.html) a non-empty [`IndexMap`](https://docs.rs/indexmap/latest/indexmap/).
+* `indexmap`: adds [`NEIndexMap`](https://docs.rs/nonempty-collections/latest/nonempty_collections/index_map/struct.NEIndexMap.html) a non-empty [`IndexMap`](https://docs.rs/indexmap/latest/indexmap/), and [`NEIndexSet`](https://docs.rs/nonempty-collections/latest/nonempty_collections/index_set/struct.NEIndexSet.html) a non-empty [`IndexSet`](https://docs.rs/indexmap/latest/indexmap/set/).
 * `itertools`: adds [`NonEmptyItertools`](https://docs.rs/nonempty-collections/latest/nonempty_collections/itertools/trait.NonEmptyItertools.html) a non-empty variant of [`itertools`](https://docs.rs/itertools/latest/itertools/).
 * `either`: adds [`NEEither`](https://docs.rs/nonempty-collections/latest/nonempty_collections/either/enum.NEEither.html) a non-empty variant of `Either` from the [`either` crate](https://docs.rs/either/latest/either/).
 * `schemars`: adds [`schemars`](https://docs.rs/schemars/1/schemars/) support.

--- a/README.md
+++ b/README.md
@@ -134,5 +134,6 @@ contains something.
 * `indexmap`: adds [`NEIndexMap`](https://docs.rs/nonempty-collections/latest/nonempty_collections/index_map/struct.NEIndexMap.html) a non-empty [`IndexMap`](https://docs.rs/indexmap/latest/indexmap/).
 * `itertools`: adds [`NonEmptyItertools`](https://docs.rs/nonempty-collections/latest/nonempty_collections/itertools/trait.NonEmptyItertools.html) a non-empty variant of [`itertools`](https://docs.rs/itertools/latest/itertools/).
 * `either`: adds [`NEEither`](https://docs.rs/nonempty-collections/latest/nonempty_collections/either/enum.NEEither.html) a non-empty variant of `Either` from the [`either` crate](https://docs.rs/either/latest/either/).
+* `schemars`: adds [`schemars`](https://docs.rs/schemars/1/schemars/) support.
 
 <!-- cargo-rdme end -->

--- a/src/either.rs
+++ b/src/either.rs
@@ -32,6 +32,12 @@ use either::Either;
 use crate::IntoNonEmptyIterator;
 use crate::NonEmptyIterator;
 
+#[cfg(feature = "schemars")]
+use ::{
+    schemars::{JsonSchema, Schema, SchemaGenerator},
+    std::borrow::Cow,
+};
+
 /// Non-empty variant of [`either::Either`] that implements
 /// [`NonEmptyIterator`].
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -90,5 +96,20 @@ where
             NEEither::Left(left) => Either::Left(left.into_iter()),
             NEEither::Right(right) => Either::Right(right.into_iter()),
         }
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<L: JsonSchema, R: JsonSchema> JsonSchema for NEEither<L, R> {
+    fn schema_name() -> Cow<'static, str> {
+        Either::<L, R>::schema_name()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        Either::<L, R>::json_schema(generator)
+    }
+
+    fn inline_schema() -> bool {
+        Either::<L, R>::inline_schema()
     }
 }

--- a/src/either.rs
+++ b/src/either.rs
@@ -38,9 +38,13 @@ use ::{
     std::borrow::Cow,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Non-empty variant of [`either::Either`] that implements
 /// [`NonEmptyIterator`].
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum NEEither<L, R> {
     /// A value of type `L`.
     Left(L),
@@ -111,5 +115,24 @@ impl<L: JsonSchema, R: JsonSchema> JsonSchema for NEEither<L, R> {
 
     fn inline_schema() -> bool {
         Either::<L, R>::inline_schema()
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::{Either, NEEither};
+
+    #[test]
+    fn json() {
+        let ne_either: NEEither<i32, f32> = NEEither::Left(123);
+        let ne_either_json = serde_json::to_string(&ne_either).unwrap();
+        let either: Either<i32, f32> = serde_json::from_str(&ne_either_json).unwrap();
+        let either_json = serde_json::to_string(&either).unwrap();
+
+        assert_eq!(&ne_either_json, &either_json);
+
+        let ne_either_2: NEEither<i32, f32> = serde_json::from_str(&either_json).unwrap();
+
+        assert_eq!(&ne_either, &ne_either_2);
     }
 }

--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -7,15 +7,21 @@ use crate::FromNonEmptyIterator;
 use crate::IntoNonEmptyIterator;
 use crate::NonEmptyIterator;
 use crate::Singleton;
-use indexmap::indexmap;
 use indexmap::Equivalent;
 use indexmap::IndexMap;
+use indexmap::indexmap;
 use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
+
+#[cfg(feature = "schemars")]
+use ::{
+    schemars::{JsonSchema, Schema, SchemaGenerator},
+    std::borrow::Cow,
+};
 
 /// Short-hand for constructing [`NEIndexMap`] values.
 ///
@@ -736,6 +742,29 @@ where
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<K: JsonSchema, V: JsonSchema> JsonSchema for super::NEIndexMap<K, V> {
+    fn schema_name() -> Cow<'static, str> {
+        IndexMap::<K, V>::schema_name()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let mut schema = IndexMap::<K, V>::json_schema(generator);
+
+        if let Some(schema_object) = schema.as_object_mut()
+            && schema_object["type"] == "object"
+        {
+            schema_object.insert("minProperties".to_string(), 1.into());
+        }
+
+        schema
+    }
+
+    fn inline_schema() -> bool {
+        IndexMap::<K, V>::inline_schema()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -797,5 +826,21 @@ mod test {
             *v -= 1;
         }
         assert_eq!(ne_indexmap! {"a" => 0, "b" => 1, "c" => 2}, v);
+    }
+
+    #[cfg(feature = "schemars")]
+    mod schemars_tests {
+        use super::{IndexMap, NEIndexMap};
+        use schemars::schema_for;
+
+        #[test]
+        fn test_simple_schema() {
+            let actual = schema_for!(NEIndexMap<i32, i32>).to_value();
+
+            let mut expected = schema_for!(IndexMap<i32, i32>).to_value();
+            expected["minProperties"] = 1.into();
+
+            assert_eq!(expected, actual);
+        }
     }
 }

--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -4,6 +4,7 @@
 //! order.
 
 use crate::FromNonEmptyIterator;
+use crate::IntoIteratorExt;
 use crate::IntoNonEmptyIterator;
 use crate::NonEmptyIterator;
 use crate::Singleton;
@@ -22,6 +23,8 @@ use ::{
     schemars::{JsonSchema, Schema, SchemaGenerator},
     std::borrow::Cow,
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Short-hand for constructing [`NEIndexMap`] values.
 ///
@@ -57,8 +60,31 @@ macro_rules! ne_indexmap {
 /// assert_eq!(2, m.len().get());
 /// ```
 #[derive(Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Deserialize, Serialize),
+    serde(bound(
+        serialize = "K: Eq + Hash + Clone + Serialize, V: Clone + Serialize, S: Clone + BuildHasher",
+        deserialize = "K: Eq + Hash + Clone + Deserialize<'de>, V: Deserialize<'de>, S: Default + BuildHasher"
+    )),
+    serde(into = "IndexMap<K, V, S>", try_from = "IndexMap<K, V, S>")
+)]
 pub struct NEIndexMap<K, V, S = std::collections::hash_map::RandomState> {
     inner: IndexMap<K, V, S>,
+}
+
+impl<K, V, S> TryFrom<IndexMap<K, V, S>> for NEIndexMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    type Error = crate::Error;
+
+    fn try_from(map: IndexMap<K, V, S>) -> Result<Self, Self::Error> {
+        map.try_into_nonempty_iter()
+            .map(NonEmptyIterator::collect)
+            .ok_or(crate::Error::Empty)
+    }
 }
 
 impl<K, V, S> NEIndexMap<K, V, S> {
@@ -826,6 +852,28 @@ mod test {
             *v -= 1;
         }
         assert_eq!(ne_indexmap! {"a" => 0, "b" => 1, "c" => 2}, v);
+    }
+
+    #[cfg(feature = "serde")]
+    #[cfg(test)]
+    mod serde_tests {
+        use indexmap::IndexMap;
+
+        use crate::NEIndexMap;
+        use crate::ne_indexmap;
+
+        #[test]
+        fn json() {
+            let map0 = ne_indexmap![1 => 'a', 2 => 'b', 1 => 'c'];
+            let j = serde_json::to_string(&map0).unwrap();
+            let map1 = serde_json::from_str(&j).unwrap();
+            assert_eq!(map0, map1);
+
+            let empty: IndexMap<usize, char> = IndexMap::new();
+            let j = serde_json::to_string(&empty).unwrap();
+            let bad = serde_json::from_str::<NEIndexMap<usize, char>>(&j);
+            assert!(bad.is_err());
+        }
     }
 
     #[cfg(feature = "schemars")]

--- a/src/index_set.rs
+++ b/src/index_set.rs
@@ -1,0 +1,781 @@
+//! Non-empty IndexSets.
+
+use core::fmt;
+use indexmap::IndexSet;
+use std::borrow::Borrow;
+use std::hash::BuildHasher;
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+
+#[cfg(feature = "schemars")]
+use ::{
+    schemars::{JsonSchema, Schema, SchemaGenerator},
+    std::borrow::Cow,
+};
+
+#[cfg(feature = "serde")]
+use serde::Deserialize;
+#[cfg(feature = "serde")]
+use serde::Serialize;
+
+use crate::FromNonEmptyIterator;
+use crate::IntoIteratorExt;
+use crate::IntoNonEmptyIterator;
+use crate::Singleton;
+use crate::iter::NonEmptyIterator;
+
+/// Like the [`crate::nev!`] macro, but for IndexSets. A nice short-hand for
+/// constructing [`NEIndexSet`] values.
+///
+/// ```
+/// use nonempty_collections::ne_indexset;
+///
+/// let s = ne_indexset![1, 2, 2, 3,];
+/// assert_eq!(3, s.len().get());
+/// ```
+#[macro_export]
+macro_rules! ne_indexset {
+    ($h:expr, $( $x:expr ),* $(,)?) => {{
+        let mut set = $crate::NEIndexSet::new($h);
+        $( set.insert($x); )*
+        set
+    }};
+    ($h:expr) => {
+        $crate::NEIndexSet::new($h)
+    }
+}
+
+/// A non-empty, growable `IndexSet`.
+///
+/// # Construction and Access
+///
+/// The [`ne_indexset`] macro is the simplest way to construct an `NEIndexSet`:
+///
+/// ```
+/// use nonempty_collections::*;
+///
+/// let s = ne_indexset![1, 1, 2, 2, 3, 3, 4, 4];
+/// let mut v: NEVec<_> = s.nonempty_iter().collect();
+/// v.sort();
+/// assert_eq!(nev![&1, &2, &3, &4], v);
+/// ```
+///
+///
+/// ```
+/// use nonempty_collections::ne_indexset;
+///
+/// let s = ne_indexset!["Fëanor", "Fingolfin", "Finarfin"];
+/// assert!(s.contains(&"Fëanor"));
+/// ```
+///
+/// # Conversion
+///
+/// If you have a [`IndexSet`] but want an `NEIndexSet`, try [`NEIndexSet::try_from_set`].
+/// Naturally, this might not succeed.
+///
+/// If you have an `NEIndexSet` but want a `IndexSet`, try their corresponding
+/// [`From`] instance. This will always succeed.
+///
+/// ```
+/// use indexmap::set::IndexSet;
+///
+/// use nonempty_collections::ne_indexset;
+///
+/// let n0 = ne_indexset![1, 2, 3];
+/// let s0 = IndexSet::from(n0);
+///
+/// // Or just use `Into`.
+/// let n1 = ne_indexset![1, 2, 3];
+/// let s1: IndexSet<_> = n1.into();
+/// ```
+///
+/// # API Differences with [`IndexSet`]
+///
+/// Note that the following methods aren't implemented for `NEIndexSet`:
+///
+/// - `clear`
+/// - `drain`
+/// - `drain_filter`
+/// - `remove`
+/// - `retain`
+/// - `take`
+///
+/// As these methods are all "mutate-in-place" style and are difficult to
+/// reconcile with the non-emptiness guarantee.
+#[allow(clippy::unsafe_derive_deserialize)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(bound(
+        serialize = "T: Eq + Hash + Clone + Serialize, S: Clone + BuildHasher",
+        deserialize = "T: Eq + Hash + Deserialize<'de>, S: Default + BuildHasher"
+    )),
+    serde(into = "IndexSet<T, S>", try_from = "IndexSet<T, S>")
+)]
+#[derive(Clone)]
+pub struct NEIndexSet<T, S = std::collections::hash_map::RandomState> {
+    inner: IndexSet<T, S>,
+}
+
+impl<T, S> NEIndexSet<T, S> {
+    /// Returns the number of elements the set can hold without reallocating.
+    #[must_use]
+    pub fn capacity(&self) -> NonZeroUsize {
+        unsafe { NonZeroUsize::new_unchecked(self.inner.capacity()) }
+    }
+
+    /// Returns a reference to the set's `BuildHasher`.
+    #[must_use]
+    pub fn hasher(&self) -> &S {
+        self.inner.hasher()
+    }
+
+    /// Returns a regular iterator over the values in this non-empty set.
+    ///
+    /// For a `NonEmptyIterator` see `Self::nonempty_iter()`.
+    pub fn iter(&self) -> indexmap::set::Iter<'_, T> {
+        self.inner.iter()
+    }
+
+    /// An iterator visiting all elements in arbitrary order.
+    pub fn nonempty_iter(&self) -> Iter<'_, T> {
+        Iter {
+            iter: self.inner.iter(),
+        }
+    }
+
+    /// Returns the number of elements in the set. Always 1 or more.
+    ///
+    /// ```
+    /// use nonempty_collections::ne_indexset;
+    ///
+    /// let s = ne_indexset![1, 2, 3];
+    /// assert_eq!(3, s.len().get());
+    /// ```
+    #[must_use]
+    pub fn len(&self) -> NonZeroUsize {
+        unsafe { NonZeroUsize::new_unchecked(self.inner.len()) }
+    }
+
+    /// A `NEIndexSet` is never empty.
+    #[deprecated(since = "0.1.0", note = "A NEIndexSet is never empty.")]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl<T> NEIndexSet<T>
+where
+    T: Eq + Hash,
+{
+    /// Creates a new `NEIndexSet` with a single element.
+    #[must_use]
+    pub fn new(value: T) -> Self {
+        let mut inner = IndexSet::new();
+        inner.insert(value);
+        Self { inner }
+    }
+
+    /// Creates a new `NEIndexSet` with a single element and specified capacity.
+    ///
+    /// ```
+    /// use std::hash::RandomState;
+    /// use std::num::NonZeroUsize;
+    ///
+    /// use nonempty_collections::*;
+    /// let set = NEIndexSet::with_capacity(NonZeroUsize::MIN, "hello");
+    /// assert_eq!(ne_indexset! {"hello"}, set);
+    /// assert!(set.capacity().get() >= 1);
+    /// ```
+    #[must_use]
+    pub fn with_capacity(capacity: NonZeroUsize, value: T) -> NEIndexSet<T> {
+        let mut inner = IndexSet::with_capacity(capacity.get());
+        inner.insert(value);
+        NEIndexSet { inner }
+    }
+}
+
+impl<T, S> NEIndexSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+    /// Attempt a conversion from a [`IndexSet`], consuming the given `IndexSet`.
+    /// Will return `None` if the `IndexSet` is empty.
+    ///
+    /// ```
+    /// use indexmap::set::IndexSet;
+    ///
+    /// use nonempty_collections::ne_indexset;
+    /// use nonempty_collections::NEIndexSet;
+    ///
+    /// let mut s = IndexSet::new();
+    /// s.extend([1, 2, 3]);
+    ///
+    /// let n = NEIndexSet::try_from_set(s);
+    /// assert_eq!(Some(ne_indexset![1, 2, 3]), n);
+    /// let s: IndexSet<()> = IndexSet::new();
+    /// assert_eq!(None, NEIndexSet::try_from_set(s));
+    /// ```
+    #[must_use]
+    pub fn try_from_set(set: IndexSet<T, S>) -> Option<NEIndexSet<T, S>> {
+        if set.is_empty() {
+            None
+        } else {
+            Some(NEIndexSet { inner: set })
+        }
+    }
+
+    /// Returns true if the set contains a value.
+    ///
+    /// ```
+    /// use nonempty_collections::ne_indexset;
+    ///
+    /// let s = ne_indexset![1, 2, 3];
+    /// assert!(s.contains(&3));
+    /// assert!(!s.contains(&10));
+    /// ```
+    #[must_use]
+    pub fn contains<Q>(&self, value: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        self.inner.contains(value)
+    }
+
+    /// Visits the values representing the difference, i.e., the values that are
+    /// in `self` but not in `other`.
+    ///
+    /// ```
+    /// use nonempty_collections::ne_indexset;
+    ///
+    /// let s0 = ne_indexset![1, 2, 3];
+    /// let s1 = ne_indexset![3, 4, 5];
+    /// let mut v: Vec<_> = s0.difference(&s1).collect();
+    /// v.sort();
+    /// assert_eq!(vec![&1, &2], v);
+    /// ```
+    pub fn difference<'a>(
+        &'a self,
+        other: &'a NEIndexSet<T, S>,
+    ) -> indexmap::set::Difference<'a, T, S> {
+        self.inner.difference(&other.inner)
+    }
+
+    /// Returns a reference to the value in the set, if any, that is equal to
+    /// the given value.
+    ///
+    /// The value may be any borrowed form of the set’s value type, but `Hash`
+    /// and `Eq` on the borrowed form must match those for the value type.
+    ///
+    /// ```
+    /// use nonempty_collections::ne_indexset;
+    ///
+    /// let s = ne_indexset![1, 2, 3];
+    /// assert_eq!(Some(&3), s.get(&3));
+    /// assert_eq!(None, s.get(&10));
+    /// ```
+    #[must_use]
+    pub fn get<Q>(&self, value: &Q) -> Option<&T>
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash,
+    {
+        self.inner.get(value)
+    }
+
+    /// Adds a value to the set.
+    ///
+    /// If the set did not have this value present, `true` is returned.
+    ///
+    /// If the set did have this value present, `false` is returned.
+    ///
+    /// ```
+    /// use nonempty_collections::ne_indexset;
+    ///
+    /// let mut s = ne_indexset![1, 2, 3];
+    /// assert_eq!(false, s.insert(2));
+    /// assert_eq!(true, s.insert(4));
+    /// ```
+    pub fn insert(&mut self, value: T) -> bool {
+        self.inner.insert(value)
+    }
+
+    /// Visits the values representing the interesection, i.e., the values that
+    /// are both in `self` and `other`.
+    ///
+    /// ```
+    /// use nonempty_collections::ne_indexset;
+    ///
+    /// let s0 = ne_indexset![1, 2, 3];
+    /// let s1 = ne_indexset![3, 4, 5];
+    /// let mut v: Vec<_> = s0.intersection(&s1).collect();
+    /// v.sort();
+    /// assert_eq!(vec![&3], v);
+    /// ```
+    pub fn intersection<'a>(
+        &'a self,
+        other: &'a NEIndexSet<T, S>,
+    ) -> indexmap::set::Intersection<'a, T, S> {
+        self.inner.intersection(&other.inner)
+    }
+
+    /// Returns `true` if `self` has no elements in common with `other`.
+    /// This is equivalent to checking for an empty intersection.
+    ///
+    /// ```
+    /// use nonempty_collections::ne_indexset;
+    ///
+    /// let s0 = ne_indexset![1, 2, 3];
+    /// let s1 = ne_indexset![4, 5, 6];
+    /// assert!(s0.is_disjoint(&s1));
+    /// ```
+    #[must_use]
+    pub fn is_disjoint(&self, other: &NEIndexSet<T, S>) -> bool {
+        self.inner.is_disjoint(&other.inner)
+    }
+
+    /// Returns `true` if the set is a subset of another, i.e., `other` contains
+    /// at least all the values in `self`.
+    ///
+    /// ```
+    /// use nonempty_collections::ne_indexset;
+    ///
+    /// let sub = ne_indexset![1, 2, 3];
+    /// let sup = ne_indexset![1, 2, 3, 4];
+    ///
+    /// assert!(sub.is_subset(&sup));
+    /// assert!(!sup.is_subset(&sub));
+    /// ```
+    #[must_use]
+    pub fn is_subset(&self, other: &NEIndexSet<T, S>) -> bool {
+        self.inner.is_subset(&other.inner)
+    }
+
+    /// Returns `true` if the set is a superset of another, i.e., `self`
+    /// contains at least all the values in `other`.
+    ///
+    /// ```
+    /// use nonempty_collections::ne_indexset;
+    ///
+    /// let sub = ne_indexset![1, 2, 3];
+    /// let sup = ne_indexset![1, 2, 3, 4];
+    ///
+    /// assert!(sup.is_superset(&sub));
+    /// assert!(!sub.is_superset(&sup));
+    /// ```
+    #[must_use]
+    pub fn is_superset(&self, other: &NEIndexSet<T, S>) -> bool {
+        self.inner.is_superset(&other.inner)
+    }
+
+    /// Adds a value to the set, replacing the existing value, if any, that is
+    /// equal to the given one. Returns the replaced value.
+    pub fn replace(&mut self, value: T) -> Option<T> {
+        self.inner.replace(value)
+    }
+
+    /// Reserves capacity for at least `additional` more elements to be inserted
+    /// in the `NEIndexSet`. The collection may reserve more space to avoid frequent
+    /// reallocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new allocation size overflows `usize`.
+    pub fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional);
+    }
+
+    /// Shrinks the capacity of the set as much as possible. It will drop down
+    /// as much as possible while maintaining the internal rules and possibly
+    /// leaving some space in accordance with the resize policy.
+    pub fn shrink_to_fit(&mut self) {
+        self.inner.shrink_to_fit();
+    }
+
+    /// Visits the values representing the union, i.e., all the values in `self`
+    /// or `other`, without duplicates.
+    ///
+    /// Note that a Union is always non-empty.
+    ///
+    /// ```
+    /// use nonempty_collections::*;
+    ///
+    /// let s0 = ne_indexset![1, 2, 3];
+    /// let s1 = ne_indexset![3, 4, 5];
+    /// let mut v: NEVec<_> = s0.union(&s1).collect();
+    /// v.sort();
+    /// assert_eq!(nev![&1, &2, &3, &4, &5], v);
+    /// ```
+    pub fn union<'a>(&'a self, other: &'a NEIndexSet<T, S>) -> Union<'a, T, S> {
+        Union {
+            inner: self.inner.union(&other.inner),
+        }
+    }
+
+    /// See [`IndexSet::with_capacity_and_hasher`].
+    #[must_use]
+    pub fn with_capacity_and_hasher(
+        capacity: NonZeroUsize,
+        hasher: S,
+        value: T,
+    ) -> NEIndexSet<T, S> {
+        let mut inner = IndexSet::with_capacity_and_hasher(capacity.get(), hasher);
+        inner.insert(value);
+        NEIndexSet { inner }
+    }
+
+    /// See [`IndexSet::with_hasher`].
+    #[must_use]
+    pub fn with_hasher(hasher: S, value: T) -> NEIndexSet<T, S> {
+        let mut inner = IndexSet::with_hasher(hasher);
+        inner.insert(value);
+        NEIndexSet { inner }
+    }
+}
+
+impl<T, S> AsRef<IndexSet<T, S>> for NEIndexSet<T, S> {
+    fn as_ref(&self) -> &IndexSet<T, S> {
+        &self.inner
+    }
+}
+
+impl<T, S> AsMut<IndexSet<T, S>> for NEIndexSet<T, S> {
+    fn as_mut(&mut self) -> &mut IndexSet<T, S> {
+        &mut self.inner
+    }
+}
+
+impl<T, S> PartialEq for NEIndexSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+    /// ```
+    /// use nonempty_collections::ne_indexset;
+    ///
+    /// let s0 = ne_indexset![1, 2, 3];
+    /// let s1 = ne_indexset![1, 2, 3];
+    /// let s2 = ne_indexset![1, 2];
+    /// let s3 = ne_indexset![1, 2, 3, 4];
+    ///
+    /// assert!(s0 == s1);
+    /// assert!(s0 != s2);
+    /// assert!(s0 != s3);
+    /// ```
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.intersection(other).count() == self.len().get()
+    }
+}
+
+impl<T, S> Eq for NEIndexSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+}
+
+impl<T, S> IntoNonEmptyIterator for NEIndexSet<T, S> {
+    type IntoNEIter = IntoIter<T>;
+
+    fn into_nonempty_iter(self) -> Self::IntoNEIter {
+        IntoIter {
+            iter: self.inner.into_iter(),
+        }
+    }
+}
+
+impl<'a, T, S> IntoNonEmptyIterator for &'a NEIndexSet<T, S> {
+    type IntoNEIter = Iter<'a, T>;
+
+    fn into_nonempty_iter(self) -> Self::IntoNEIter {
+        self.nonempty_iter()
+    }
+}
+
+impl<T, S> IntoIterator for NEIndexSet<T, S> {
+    type Item = T;
+
+    type IntoIter = indexmap::set::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
+impl<'a, T, S> IntoIterator for &'a NEIndexSet<T, S> {
+    type Item = &'a T;
+
+    type IntoIter = indexmap::set::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// ```
+/// use nonempty_collections::*;
+///
+/// let s0 = ne_indexset![1, 2, 3];
+/// let s1: NEIndexSet<_> = s0.nonempty_iter().cloned().collect();
+/// assert_eq!(s0, s1);
+/// ```
+impl<T, S> FromNonEmptyIterator<T> for NEIndexSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    /// ```
+    /// use nonempty_collections::*;
+    ///
+    /// let v = nev![1, 1, 2, 3, 2];
+    /// let s = NEIndexSet::from_nonempty_iter(v);
+    ///
+    /// assert_eq!(ne_indexset![1, 2, 3], s);
+    /// ```
+    fn from_nonempty_iter<I>(iter: I) -> Self
+    where
+        I: IntoNonEmptyIterator<Item = T>,
+    {
+        NEIndexSet {
+            inner: iter.into_nonempty_iter().into_iter().collect(),
+        }
+    }
+}
+
+/// A non-empty iterator over the values of an [`NEIndexSet`].
+#[must_use = "non-empty iterators are lazy and do nothing unless consumed"]
+pub struct Iter<'a, T: 'a> {
+    iter: indexmap::set::Iter<'a, T>,
+}
+
+impl<'a, T: 'a> IntoIterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    type IntoIter = indexmap::set::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter
+    }
+}
+
+impl<T> NonEmptyIterator for Iter<'_, T> {}
+
+impl<T: fmt::Debug> fmt::Debug for Iter<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.iter.fmt(f)
+    }
+}
+
+/// An owned non-empty iterator over the values of an [`NEIndexSet`].
+#[must_use = "non-empty iterators are lazy and do nothing unless consumed"]
+pub struct IntoIter<T> {
+    iter: indexmap::set::IntoIter<T>,
+}
+
+impl<T> IntoIterator for IntoIter<T> {
+    type Item = T;
+
+    type IntoIter = indexmap::set::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter
+    }
+}
+
+impl<T> NonEmptyIterator for IntoIter<T> {}
+
+impl<T: fmt::Debug> fmt::Debug for IntoIter<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.iter.fmt(f)
+    }
+}
+
+/// A non-empty iterator producing elements in the union of two [`NEIndexSet`]s.
+#[must_use = "non-empty iterators are lazy and do nothing unless consumed"]
+pub struct Union<'a, T: 'a, S: 'a> {
+    inner: indexmap::set::Union<'a, T, S>,
+}
+
+impl<'a, T, S> IntoIterator for Union<'a, T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+    type Item = &'a T;
+
+    type IntoIter = indexmap::set::Union<'a, T, S>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner
+    }
+}
+
+impl<T, S> NonEmptyIterator for Union<'_, T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+}
+
+impl<T, S> fmt::Debug for Union<'_, T, S>
+where
+    T: fmt::Debug + Eq + Hash,
+    S: BuildHasher,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl<T, S> From<NEIndexSet<T, S>> for IndexSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+    /// ```
+    /// use indexmap::set::IndexSet;
+    ///
+    /// use nonempty_collections::ne_indexset;
+    ///
+    /// let s: IndexSet<_> = ne_indexset![1, 2, 3].into();
+    /// let mut v: Vec<_> = s.into_iter().collect();
+    /// v.sort();
+    /// assert_eq!(vec![1, 2, 3], v);
+    /// ```
+    fn from(s: NEIndexSet<T, S>) -> Self {
+        s.inner
+    }
+}
+
+impl<T: fmt::Debug, S> fmt::Debug for NEIndexSet<T, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl<T, S> TryFrom<IndexSet<T, S>> for NEIndexSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher + Default,
+{
+    type Error = crate::Error;
+
+    fn try_from(set: IndexSet<T, S>) -> Result<Self, Self::Error> {
+        let ne = set
+            .try_into_nonempty_iter()
+            .ok_or(crate::Error::Empty)?
+            .collect();
+
+        Ok(ne)
+    }
+}
+
+impl<T> Singleton for NEIndexSet<T>
+where
+    T: Eq + Hash,
+{
+    type Item = T;
+
+    /// ```
+    /// use nonempty_collections::{NEIndexSet, Singleton, ne_indexset};
+    ///
+    /// let s = NEIndexSet::singleton(1);
+    /// assert_eq!(ne_indexset![1], s);
+    /// ```
+    fn singleton(item: Self::Item) -> Self {
+        NEIndexSet::new(item)
+    }
+}
+
+impl<T> Extend<T> for NEIndexSet<T>
+where
+    T: Eq + Hash,
+{
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.inner.extend(iter);
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T: JsonSchema> JsonSchema for super::NEIndexSet<T> {
+    fn schema_name() -> Cow<'static, str> {
+        IndexSet::<T>::schema_name()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let mut schema = IndexSet::<T>::json_schema(generator);
+
+        if let Some(schema_object) = schema.as_object_mut()
+            && schema_object["type"] == "array"
+        {
+            schema_object.insert("minItems".to_string(), 1.into());
+        }
+
+        schema
+    }
+
+    fn inline_schema() -> bool {
+        IndexSet::<T>::inline_schema()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use maplit::hashset;
+
+    #[test]
+    fn debug_impl() {
+        let expected = format!("{:?}", hashset! {0});
+        let actual = format!("{:?}", ne_indexset! {0});
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn iter_debug_impl() {
+        let expected = format!("{:?}", hashset! {0}.iter());
+        let actual = format!("{:?}", ne_indexset! {0}.nonempty_iter());
+        assert_eq!(expected, actual);
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg(test)]
+mod serde_tests {
+    use crate::NEIndexSet;
+    #[allow(unused)]
+    use crate::ne_indexset;
+    use indexmap::set::IndexSet;
+
+    #[test]
+    fn json() {
+        let set0 = ne_indexset![1, 1, 2, 3, 2, 1, 4];
+        let j = serde_json::to_string(&set0).unwrap();
+        let set1 = serde_json::from_str(&j).unwrap();
+        assert_eq!(set0, set1);
+
+        let empty: IndexSet<usize> = IndexSet::new();
+        let j = serde_json::to_string(&empty).unwrap();
+        let bad = serde_json::from_str::<NEIndexSet<usize>>(&j);
+        assert!(bad.is_err());
+    }
+}
+
+#[cfg(feature = "schemars")]
+#[cfg(test)]
+mod schemars_tests {
+    use super::{IndexSet, NEIndexSet};
+    use schemars::schema_for;
+
+    #[test]
+    fn test_simple_schema() {
+        let actual = schema_for!(NEIndexSet<i32>).to_value();
+
+        let mut expected = schema_for!(IndexSet<i32>).to_value();
+        expected["minItems"] = 1.into();
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,8 @@ pub mod vector;
 pub mod either;
 #[cfg(feature = "indexmap")]
 pub mod index_map;
+#[cfg(feature = "indexmap")]
+pub mod index_set;
 #[cfg(feature = "itertools")]
 pub mod itertools;
 
@@ -154,6 +156,8 @@ pub use array::NonEmptyArrayExt;
 pub use either::NEEither;
 #[cfg(feature = "indexmap")]
 pub use index_map::NEIndexMap;
+#[cfg(feature = "indexmap")]
+pub use index_set::NEIndexSet;
 pub use iter::FromNonEmptyIterator;
 pub use iter::IntoIteratorExt;
 pub use iter::IntoNonEmptyIterator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@
 //! * `indexmap`: adds [`NEIndexMap`](crate::index_map::NEIndexMap) a non-empty [`IndexMap`](https://docs.rs/indexmap/latest/indexmap/).
 //! * `itertools`: adds [`NonEmptyItertools`](crate::itertools::NonEmptyItertools) a non-empty variant of [`itertools`](https://docs.rs/itertools/latest/itertools/).
 //! * `either`: adds [`NEEither`](crate::either::NEEither) a non-empty variant of `Either` from the [`either` crate](https://docs.rs/either/latest/either/).
+//! * `schemars`: adds [`schemars`](https://docs.rs/schemars/1/schemars/) support.
 
 pub mod array;
 pub mod iter;

--- a/src/map.rs
+++ b/src/map.rs
@@ -7,6 +7,12 @@ use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
 
+#[cfg(feature = "schemars")]
+use ::{
+    schemars::{JsonSchema, Schema, SchemaGenerator},
+    std::borrow::Cow,
+};
+
 #[cfg(feature = "serde")]
 use serde::Deserialize;
 #[cfg(feature = "serde")]
@@ -694,6 +700,29 @@ where
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<K: JsonSchema, V: JsonSchema> JsonSchema for super::NEMap<K, V> {
+    fn schema_name() -> Cow<'static, str> {
+        HashMap::<K, V>::schema_name()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let mut schema = HashMap::<K, V>::json_schema(generator);
+
+        if let Some(schema_object) = schema.as_object_mut()
+            && schema_object["type"] == "object"
+        {
+            schema_object.insert("minProperties".to_string(), 1.into());
+        }
+
+        schema
+    }
+
+    fn inline_schema() -> bool {
+        HashMap::<K, V>::inline_schema()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::num::NonZeroUsize;
@@ -756,8 +785,8 @@ mod test {
 mod serde_tests {
     use std::collections::HashMap;
 
-    use crate::nem;
     use crate::NEMap;
+    use crate::nem;
 
     #[test]
     fn json() {
@@ -770,5 +799,22 @@ mod serde_tests {
         let j = serde_json::to_string(&empty).unwrap();
         let bad = serde_json::from_str::<NEMap<usize, char>>(&j);
         assert!(bad.is_err());
+    }
+}
+
+#[cfg(feature = "schemars")]
+#[cfg(test)]
+mod schemars_tests {
+    use super::{HashMap, NEMap};
+    use schemars::schema_for;
+
+    #[test]
+    fn test_simple_schema() {
+        let actual = schema_for!(NEMap<String, i32>).to_value();
+
+        let mut expected = schema_for!(HashMap<String, i32>).to_value();
+        expected["minProperties"] = 1.into();
+
+        assert_eq!(expected, actual);
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -7,16 +7,22 @@ use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
 
+#[cfg(feature = "schemars")]
+use ::{
+    schemars::{JsonSchema, Schema, SchemaGenerator},
+    std::borrow::Cow,
+};
+
 #[cfg(feature = "serde")]
 use serde::Deserialize;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
-use crate::iter::NonEmptyIterator;
 use crate::FromNonEmptyIterator;
 use crate::IntoIteratorExt;
 use crate::IntoNonEmptyIterator;
 use crate::Singleton;
+use crate::iter::NonEmptyIterator;
 
 /// Like the [`crate::nev!`] macro, but for Sets. A nice short-hand for
 /// constructing [`NESet`] values.
@@ -689,6 +695,29 @@ where
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T: JsonSchema> JsonSchema for super::NESet<T> {
+    fn schema_name() -> Cow<'static, str> {
+        HashSet::<T>::schema_name()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let mut schema = HashSet::<T>::json_schema(generator);
+
+        if let Some(schema_object) = schema.as_object_mut()
+            && schema_object["type"] == "array"
+        {
+            schema_object.insert("minItems".to_string(), 1.into());
+        }
+
+        schema
+    }
+
+    fn inline_schema() -> bool {
+        HashSet::<T>::inline_schema()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use maplit::hashset;
@@ -713,8 +742,8 @@ mod test {
 mod serde_tests {
     use std::collections::HashSet;
 
-    use crate::nes;
     use crate::NESet;
+    use crate::nes;
 
     #[test]
     fn json() {
@@ -727,5 +756,22 @@ mod serde_tests {
         let j = serde_json::to_string(&empty).unwrap();
         let bad = serde_json::from_str::<NESet<usize>>(&j);
         assert!(bad.is_err());
+    }
+}
+
+#[cfg(feature = "schemars")]
+#[cfg(test)]
+mod schemars_tests {
+    use super::{HashSet, NESet};
+    use schemars::schema_for;
+
+    #[test]
+    fn test_simple_schema() {
+        let actual = schema_for!(NESet<i32>).to_value();
+
+        let mut expected = schema_for!(HashSet<i32>).to_value();
+        expected["minItems"] = 1.into();
+
+        assert_eq!(expected, actual);
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,15 +1,21 @@
 //! Non-empty Vectors.
 
+use crate::Singleton;
 use crate::iter::FromNonEmptyIterator;
 use crate::iter::IntoNonEmptyIterator;
 use crate::iter::NonEmptyIterator;
 use crate::slice::NEChunks;
-use crate::Singleton;
 use core::fmt;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::num::NonZeroUsize;
+
+#[cfg(feature = "schemars")]
+use ::{
+    schemars::{JsonSchema, Schema, SchemaGenerator},
+    std::borrow::Cow,
+};
 
 #[cfg(feature = "serde")]
 use serde::Deserialize;
@@ -1206,10 +1212,33 @@ impl<T> Singleton for NEVec<T> {
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T: JsonSchema> JsonSchema for NEVec<T> {
+    fn schema_name() -> Cow<'static, str> {
+        Vec::<T>::schema_name()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let mut schema = Vec::<T>::json_schema(generator);
+
+        if let Some(schema_object) = schema.as_object_mut()
+            && schema_object["type"] == "array"
+        {
+            schema_object.insert("minItems".to_string(), 1.into());
+        }
+
+        schema
+    }
+
+    fn inline_schema() -> bool {
+        Vec::<T>::inline_schema()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::nev;
     use crate::NEVec;
+    use crate::nev;
 
     #[derive(Debug, Clone, PartialEq)]
     struct Foo {
@@ -1439,5 +1468,21 @@ mod tests {
             }
         });
         assert_eq!(Ok(nev![4]), result, "only 3+1 = 4 should remain");
+    }
+
+    #[cfg(feature = "schemars")]
+    mod schemars {
+        use super::NEVec;
+        use schemars::schema_for;
+
+        #[test]
+        fn test_simple_schema() {
+            let actual = schema_for!(NEVec<i32>).to_value();
+
+            let mut expected = schema_for!(Vec<i32>).to_value();
+            expected["minItems"] = 1.into();
+
+            assert_eq!(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
Adds NEIndexSet wrapping indexmap::IndexSet feature-gated to its dependency. The implementation is mostly copy-pasted from the existing NESet one.

This PR builds on the schemars PR (#45) and thus includes all of its commits as well.

Like its parent PR I will not be addressing merge conflicts or change requests. Feel free to merge or close it as is, or use it as a starting point for your own implementation. 

Either way, thank you for your work!

Closes #50 