### PR TITLE
Add `try_from_iterator` methods

### DIFF
--- a/src/btree_map.rs
+++ b/src/btree_map.rs
@@ -96,6 +96,32 @@ impl<K, V> NEBTreeMap<K, V> {
         }
     }
 
+    /// Creates a new non-empty map by consuming an iterator if it is non-empty,
+    /// returns `None` otherwise.
+    ///
+    /// # Example Use
+    ///
+    /// ```
+    /// use nonempty_collections::nebtm;
+    /// use nonempty_collections::NEBTreeMap;
+    ///
+    /// let map = NEBTreeMap::try_from_iterator((0 as u8..=5).map(|n| {
+    ///     let i = n % 3;
+    ///     ((97 + i) as char, i)
+    /// }));
+    /// assert_eq!(map, Some(nebtm! {'a' => 0, 'b' => 1, 'c' => 2 }));
+    ///
+    /// let empty_map: Option<NEBTreeMap<char, &u32>> = NEBTreeMap::try_from_iterator(std::iter::empty());
+    /// assert!(empty_map.is_none());
+    /// ```
+    #[must_use]
+    pub fn try_from_iterator(i: impl IntoIterator<Item = (K, V)>) -> Option<Self>
+    where
+        K: Ord,
+    {
+        Self::try_from_map(i.into_iter().collect())
+    }
+
     /// Returns a regular iterator over the entries in this non-empty map.
     ///
     /// For a `NonEmptyIterator` see `Self::nonempty_iter()`.

--- a/src/btree_set.rs
+++ b/src/btree_set.rs
@@ -170,6 +170,26 @@ where
         }
     }
 
+    /// Creates a new non-empty set by consuming an iterator if it is non-empty,
+    /// returns `None` otherwise.
+    ///
+    /// # Example Use
+    ///
+    /// ```
+    /// use nonempty_collections::nebts;
+    /// use nonempty_collections::NEBTreeSet;
+    ///
+    /// let set = NEBTreeSet::try_from_iterator((0..=5).map(|n| n % 3));
+    /// assert_eq!(set, Some(nebts![0, 1, 2]));
+    ///
+    /// let empty_set: Option<NEBTreeSet<&u32>> = NEBTreeSet::try_from_iterator(std::iter::empty());
+    /// assert!(empty_set.is_none());
+    /// ```
+    #[must_use]
+    pub fn try_from_iterator(i: impl IntoIterator<Item = T>) -> Option<Self> {
+        Self::try_from_set(i.into_iter().collect())
+    }
+
     /// Returns true if the set contains a value.
     ///
     /// ```

--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -256,6 +256,32 @@ where
         }
     }
 
+    /// Creates a new non-empty map by consuming an iterator if it is non-empty,
+    /// returns `None` otherwise.
+    ///
+    /// # Example Use
+    ///
+    /// ```
+    /// use nonempty_collections::neim;
+    /// use nonempty_collections::NEIndexMap;
+    ///
+    /// let map = NEIndexMap::<_, _, std::hash::RandomState>::try_from_iterator((0 as u8..=5).rev().map(|n| {
+    ///     let i = n % 3;
+    ///     ((97 + i) as char, i)
+    /// }));
+    /// assert!(map.is_some_and(|m| m.into_iter().eq(neim! {'c' => 2, 'b' => 1, 'a' => 0 })));
+    ///
+    /// let empty_map: Option<NEIndexMap<char, &u32>> = NEIndexMap::try_from_iterator(std::iter::empty());
+    /// assert!(empty_map.is_none());
+    /// ```
+    #[must_use]
+    pub fn try_from_iterator(i: impl IntoIterator<Item = (K, V)>) -> Option<Self>
+    where
+        S: Default,
+    {
+        Self::try_from_map(i.into_iter().collect())
+    }
+
     /// Returns true if the map contains a value.
     ///
     /// ```

--- a/src/index_set.rs
+++ b/src/index_set.rs
@@ -205,6 +205,29 @@ where
         }
     }
 
+    /// Creates a new non-empty set by consuming an iterator if it is non-empty,
+    /// returns `None` otherwise.
+    ///
+    /// # Example Use
+    ///
+    /// ```
+    /// use nonempty_collections::neis;
+    /// use nonempty_collections::NEIndexSet;
+    ///
+    /// let set = NEIndexSet::<_, std::hash::RandomState>::try_from_iterator((0..=5).rev().map(|n| n % 3));
+    /// assert!(set.is_some_and(|s| s.into_iter().eq(neis![2, 1, 0])));
+    ///
+    /// let empty_set: Option<NEIndexSet<&u32>> = NEIndexSet::try_from_iterator(std::iter::empty());
+    /// assert!(empty_set.is_none());
+    /// ```
+    #[must_use]
+    pub fn try_from_iterator(i: impl IntoIterator<Item = T>) -> Option<Self>
+    where
+        S: Default,
+    {
+        Self::try_from_set(i.into_iter().collect())
+    }
+
     /// Returns true if the set contains a value.
     ///
     /// ```

--- a/src/map.rs
+++ b/src/map.rs
@@ -114,6 +114,33 @@ impl<K, V, S> NEMap<K, V, S> {
         }
     }
 
+    /// Creates a new non-empty map by consuming an iterator if it is non-empty,
+    /// returns `None` otherwise.
+    ///
+    /// # Example Use
+    ///
+    /// ```
+    /// use nonempty_collections::nem;
+    /// use nonempty_collections::NEMap;
+    ///
+    /// let map = NEMap::try_from_iterator((0 as u8..=5).map(|n| {
+    ///     let i = n % 3;
+    ///     ((97 + i) as char, i)
+    /// }));
+    /// assert_eq!(map, Some(nem! {'a' => 0, 'b' => 1, 'c' => 2 }));
+    ///
+    /// let empty_map: Option<NEMap<char, &u32>> = NEMap::try_from_iterator(std::iter::empty());
+    /// assert!(empty_map.is_none());
+    /// ```
+    #[must_use]
+    pub fn try_from_iterator(i: impl IntoIterator<Item = (K, V)>) -> Option<Self>
+    where
+        K: Eq + Hash,
+        S: Default + BuildHasher,
+    {
+        Self::try_from_map(i.into_iter().collect())
+    }
+
     /// Returns the number of elements the map can hold without reallocating.
     #[must_use]
     pub fn capacity(&self) -> NonZeroUsize {

--- a/src/set.rs
+++ b/src/set.rs
@@ -220,6 +220,29 @@ where
         }
     }
 
+    /// Creates a new non-empty set by consuming an iterator if it is non-empty,
+    /// returns `None` otherwise.
+    ///
+    /// # Example Use
+    ///
+    /// ```
+    /// use nonempty_collections::nes;
+    /// use nonempty_collections::NESet;
+    ///
+    /// let set = NESet::try_from_iterator((0..=5).map(|n| n % 3));
+    /// assert_eq!(set, Some(nes![0, 1, 2]));
+    ///
+    /// let empty_set: Option<NESet<&u32>> = NESet::try_from_iterator(std::iter::empty());
+    /// assert!(empty_set.is_none());
+    /// ```
+    #[must_use]
+    pub fn try_from_iterator(i: impl IntoIterator<Item = T>) -> Option<Self>
+    where
+        S: Default,
+    {
+        Self::try_from_set(i.into_iter().collect())
+    }
+
     /// Returns true if the set contains a value.
     ///
     /// ```

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -536,6 +536,26 @@ impl<T> NEVec<T> {
         }
     }
 
+    /// Creates a new non-empty vec by consuming an iterator if it is non-empty,
+    /// returns `None` otherwise.
+    ///
+    /// # Example Use
+    ///
+    /// ```
+    /// use nonempty_collections::nev;
+    /// use nonempty_collections::NEVec;
+    ///
+    /// let v_vec = NEVec::try_from_iterator(1..=5);
+    /// assert_eq!(v_vec, Some(nev![1, 2, 3, 4, 5]));
+    ///
+    /// let empty_vec: Option<NEVec<&u32>> = NEVec::try_from_iterator(std::iter::empty());
+    /// assert!(empty_vec.is_none());
+    /// ```
+    #[must_use]
+    pub fn try_from_iterator(i: impl IntoIterator<Item = T>) -> Option<Self> {
+        Self::try_from_vec(i.into_iter().collect())
+    }
+
     /// Deconstruct a `NEVec` into its head and tail. This operation never fails
     /// since we are guaranteed to have a head element.
     ///


### PR DESCRIPTION
`TryFrom<I>` where `I` implements `IntoIterator` cannot be implemented because of the conflict with the blanket implementations. This PR provides a workaround. 

Iterators are collected into the respective inner containers, bringing no performance benefit, but it provides a unified convenient API.
